### PR TITLE
Add neon install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ make install
 ```
 
 ### On Neon Postgres
-To quickly install the **pg_mooncake** extension on Neon, [create a Neon project](https://console.neon.tech/signup) and running the following commands from the [Neon SQL Editor](https://neon.tech/docs/get-started-with-neon/query-with-neon-sql-editor) or a [connected SQL client such as psql](https://neon.tech/docs/connect/query-with-psql-editor):
+To quickly install the **pg_mooncake** extension on Neon, [create a Neon project](https://console.neon.tech/signup) and run the following commands from the [Neon SQL Editor](https://neon.tech/docs/get-started-with-neon/query-with-neon-sql-editor) or a [connected SQL client such as psql](https://neon.tech/docs/connect/query-with-psql-editor):
 ```sql
 SET neon.allow_unstable_extensions='true';
 CREATE EXTENSION pg_mooncake;

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ make release
 make install
 ```
 
-### On Neon Postgres
-To quickly install the **pg_mooncake** extension on Neon, [create a Neon project](https://console.neon.tech/signup) and run the following commands from the [Neon SQL Editor](https://neon.tech/docs/get-started-with-neon/query-with-neon-sql-editor) or a [connected SQL client such as psql](https://neon.tech/docs/connect/query-with-psql-editor):
+### On Neon Postgres:
+To quickly install the **pg_mooncake** extension on Neon, [create a Neon project](https://console.neon.tech/signup) and run the following command from the [Neon SQL Editor](https://neon.tech/docs/get-started-with-neon/query-with-neon-sql-editor) or a [connected SQL client such as psql](https://neon.tech/docs/connect/query-with-psql-editor) before you enable the extension.
 ```sql
 SET neon.allow_unstable_extensions='true';
-CREATE EXTENSION pg_mooncake;
+```
 
 ### Enable the Extension:
 ```sql

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **pg_mooncake** is a PostgreSQL extension that adds native columnstore tables with DuckDB execution. Columnstore tables are stored as [Iceberg](https://github.com/apache/iceberg) or [Delta Lake](https://github.com/delta-io/delta) tables in object storage.
 
-The extension is maintained by [Mooncake Labs](https://mooncake.dev/) and is available on [Neon](https://github.com/neondatabase/neon).
+The extension is maintained by [Mooncake Labs](https://mooncake.dev/) and is available on [Neon Postgres](https://neon.tech/home).
 
 ```sql
 -- Create a columnstore table in PostgreSQL
@@ -23,7 +23,7 @@ SELECT * FROM user_activity LIMIT 5;
 
 
 ## Installation
-You can install **pg_mooncake** using either our Docker image or from source.
+You can install **pg_mooncake** using our Docker image, from source, or on [Neon Postgres](https://neon.tech/home).
 
 ### Docker Image:
 To quickly get a PostgreSQL instance with **pg_mooncake** extension up and running, pull and run the latest Docker image:
@@ -43,6 +43,12 @@ git submodule update --init --recursive
 make release
 make install
 ```
+
+### On Neon Postgres
+To quickly install the **pg_mooncake** extension on Neon, [create a Neon project](https://console.neon.tech/signup) and running the following commands from the [Neon SQL Editor](https://neon.tech/docs/get-started-with-neon/query-with-neon-sql-editor) or a [connected SQL client such as psql](https://neon.tech/docs/connect/query-with-psql-editor):
+```sql
+SET neon.allow_unstable_extensions='true';
+CREATE EXTENSION pg_mooncake;
 
 ### Enable the Extension:
 ```sql


### PR DESCRIPTION
Add Neon install instructions. There's a SET command you need to run before enabling the extension on Neon. It will help users to provide this information in the pg_mooncake readme.