### PR TITLE
Improve `CONTRIBUTING.md` instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ make debug
 make install
 ```
 Then, connect to Postgres using `psql`.
-Once connected to psql, you can enable the extension and begin development:
+
+Once connected, you can enable the extension and begin development:
 ```sql
 CREATE EXTENSION pg_mooncake;
 ```
@@ -39,7 +40,7 @@ This pid (1219 in this case) indicates the process that you should attach the de
 3. Set Breakpoints and Debug: With the debugger attached, you can set breakpoints within the code. This allows you to step through the code execution, inspect variables, and fully debug the Postgres instance running in your container.
 
 ## Testing
-* Tests use standard regression tests for Postgres extensions. To run tests, run `make installcheck`.
+Tests use standard regression tests for Postgres extensions. To run tests, run `make installcheck`.
 
 ## Formatting
-* Ensure to run `make format` to format the code.
+Ensure to run `make format` to format the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,5 +41,8 @@ This pid (1219 in this case) indicates the process that you should attach the de
 
 3. Set Breakpoints and Debug: With the debugger attached, you can set breakpoints within the code. This allows you to step through the code execution, inspect variables, and fully debug the Postgres instance running in your container.
 
+## Testing
+* Tests use standard regression tests for Postgres extensions. To run tests, run make installcheck.
+
 ## Formatting
 * Ensure to run `make format` to format the code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,18 @@ This will create an isolated Workspace in vscode, including all tools required t
 
 Now you can compile and install the extension
 ```bash
+git submodule update --init --recursive
 make debug
 make install
 ```
-then connect to Postgres using `psql`.
+Then, connect to PostgreSQL using psql:
+```bash
+psql -U postgres -d mooncake
+```
+Once connected to psql, you can enable the extension and begin development:
+```sql
+CREATE EXTENSION pg_mooncake;
+```
 
 ### Debugging
 1. Identify the Process: Take note of the pid that appears in your psql prompt. For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,7 @@ git submodule update --init --recursive
 make debug
 make install
 ```
-Then, connect to PostgreSQL using psql:
-```bash
-psql -U postgres -d mooncake
-```
+Then, connect to Postgres using `psql`.
 Once connected to psql, you can enable the extension and begin development:
 ```sql
 CREATE EXTENSION pg_mooncake;
@@ -42,7 +39,7 @@ This pid (1219 in this case) indicates the process that you should attach the de
 3. Set Breakpoints and Debug: With the debugger attached, you can set breakpoints within the code. This allows you to step through the code execution, inspect variables, and fully debug the Postgres instance running in your container.
 
 ## Testing
-* Tests use standard regression tests for Postgres extensions. To run tests, run make installcheck.
+* Tests use standard regression tests for Postgres extensions. To run tests, run `make installcheck`.
 
 ## Formatting
 * Ensure to run `make format` to format the code.


### PR DESCRIPTION
This PR improves the `CONTRIBUTING.md` by:
- Adding missing steps for initializing submodules with `git submodule update`.
- Providing clear instructions for connecting to PostgreSQL using `psql`.
- Explaining how to enable the `pg_mooncake` extension after connecting to `psql`.
- Adding the test process