### PR TITLE
Update README for parallel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run -it --rm --link mooncake-demo:postgres mooncakelabs/pg_mooncake psql 
 You can compile and install **pg_mooncake** extension to add it to your PostgreSQL instance. PostgreSQL versions 15, 16, and 17 are currently supported.
 ```bash
 git submodule update --init --recursive
-make release
+make release -j`nproc`
 make install
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run -it --rm --link mooncake-demo:postgres mooncakelabs/pg_mooncake psql 
 You can compile and install **pg_mooncake** extension to add it to your PostgreSQL instance. PostgreSQL versions 15, 16, and 17 are currently supported.
 ```bash
 git submodule update --init --recursive
-make release -j`nproc`
+make release -j$(nproc)
 make install
 ```
 


### PR DESCRIPTION
Related to issue: https://github.com/Mooncake-Labs/pg_mooncake/issues/39

After some experiment, I found
- Commit attempting to perform parallel compilation (https://github.com/Mooncake-Labs/pg_mooncake/commit/b71e7e1118fee45147aa955963ba8154b2ae8e28) only improves part of the performance
- While `make release -j$(nproc)` seems to utilize all the available CPU core on my VM

Paste the `htop` screenshot below:
- Screenshot for latest master branch
![image](https://github.com/user-attachments/assets/e0795b9d-7432-41e5-ae23-70e7da7a5b63)
- Screenshot after the proposed change
![image](https://github.com/user-attachments/assets/472cc398-20ec-4ea8-9868-391e51f8c7b1)

The above screenshot clearly shows the later utilize the CPU cores much better.
Below is my **guess**, no concrete proof:
- Last parallel commit only changes the parallelism to build duckdb, but there're quite a few other targets to build as well, for example, rust binding for deltalake, jemalloc, httpfs, etc
- Specifying parallelism in the `make` command helps parallel compiling all dependent targets