### PR TITLE
Rename duckdb scan method name

### DIFF
--- a/src/pgduckdb/pgduckdb_node.cpp
+++ b/src/pgduckdb/pgduckdb_node.cpp
@@ -250,13 +250,13 @@ extern "C" void
 DuckdbInitNode() {
 	/* setup scan methods */
 	memset(&duckdb_scan_scan_methods, 0, sizeof(duckdb_scan_scan_methods));
-	duckdb_scan_scan_methods.CustomName = "DuckDBScan";
+	duckdb_scan_scan_methods.CustomName = "MooncakeDuckDBScan";
 	duckdb_scan_scan_methods.CreateCustomScanState = Duckdb_CreateCustomScanState;
 	RegisterCustomScanMethods(&duckdb_scan_scan_methods);
 
 	/* setup exec methods */
 	memset(&duckdb_scan_exec_methods, 0, sizeof(duckdb_scan_exec_methods));
-	duckdb_scan_exec_methods.CustomName = "DuckDBScan";
+	duckdb_scan_exec_methods.CustomName = "MooncakeDuckDBScan";
 
 	duckdb_scan_exec_methods.BeginCustomScan = Duckdb_BeginCustomScan;
 	duckdb_scan_exec_methods.ExecCustomScan = Duckdb_ExecCustomScan;


### PR DESCRIPTION
Problem statement:
If you use pg_duckdb and pg_mooncake at the same time, SQL statements would fail due to scan naming conflict.

Example SQL statements:
```
postgres=# \x
Expanded display is on.
postgres=# SHOW shared_preload_libraries;
-[ RECORD 1 ]------------+----------
shared_preload_libraries | pg_duckdb

postgres=# CREATE EXTENSION pg_duckdb;
CREATE EXTENSION
postgres=# SET duckdb.force_execution TO true;
SET
postgres=# CREATE TABLE pgduckdb_test_tbl (val int);
CREATE TABLE
postgres=# CREATE TABLE mooncake_test_tbl (val int) USING columnstore;
ERROR:  extensible node type "DuckDBScan" already exists
```
I confirm after my fix and re-install, the issue gets resolved.

I understand pg_mooncake directly bakes pg_duckdb inside of the plugin, but I think having a different name is necessary and reasonable:
- These two plugins are made from different companies and serve for different purposes (i.e. mooncake supports write, while pg_duckdb supports motherduck), in the future they could optimize for different purposes, since read and write workload don't always play well with each other, so having two plugins coexist in one pg instance is reasonable;
- One concern is to keep as little change to pg_duckdb as possible, since mooncake team has to maintain and upgrade; the naming change is so trivial that I don't imagine it causing headache to upgrade.