### PR TITLE
Make clean should delete duckdb as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release:
 debug:
 	@$(MAKE) BUILD_TYPE=debug all
 
-clean: clean-delta
+clean: clean-delta clean-duckdb
 	rm -rf build
 
 format: format-delta


### PR DESCRIPTION
I think `make clean` command should cleanup all targets that we build.