### PR TITLE
Disallow out of range numerics type on table creation

### DIFF
--- a/test/expected/unsupported/types.out
+++ b/test/expected/unsupported/types.out
@@ -3,3 +3,7 @@ ERROR:  column "a" has unsupported type
 CREATE TYPE point AS (x int, y int);
 CREATE TABLE t (a point) USING columnstore;
 ERROR:  column "a" has unsupported type
+CREATE TABLE mooncake_numeric_tbl (val numeric(40, 5)) USING columnstore;
+ERROR:  Unsupported type when creating column: type precision 40 with scale 5 is not supported by duckdb, which only allows maximum precision 38
+CREATE TABLE mooncake_numeric_tbl (val numeric) USING columnstore;
+ERROR:  Unsupported type when creating column: type precision 65535 with scale -5 is not supported by duckdb, which only allows maximum precision 38

--- a/test/sql/unsupported/types.sql
+++ b/test/sql/unsupported/types.sql
@@ -2,3 +2,6 @@ CREATE TABLE t (a jsonb) USING columnstore;
 
 CREATE TYPE point AS (x int, y int);
 CREATE TABLE t (a point) USING columnstore;
+
+CREATE TABLE mooncake_numeric_tbl (val numeric(40, 5)) USING columnstore;
+CREATE TABLE mooncake_numeric_tbl (val numeric) USING columnstore;


### PR DESCRIPTION
Followup PR for issue https://github.com/Mooncake-Labs/pg_mooncake/issues/47
This PR disallows table creation when out-of-range (for duckdb) numerics types created.

The implementation here copies the type checking logic into `columnstore_handle.cpp`.
Pro: Having the check logic outside of pg_duckdb reduces the overhead for upgrade
Con: Need to maintain two util functions to get scale and width, every time we upgrade pg_duckdb.

Alternative considered: 
Method-1: add extra type conversion code in pg_duckdb.
Example code
```
if (scale > 38) return duckdb::USER(...)
```
Pro: least possible code change
Con: every time we upgrade pg_duckdb, the extra checking logic has to be cherry-picked also

Method-2: propagate the logic to table creation logic into pg_duckdb
It doesn't work because pg_duckdb doesn't support general-purpose table creation as of now;
Moving the logic into pg type -> duck type conversion is also not proper.

How I tested:
```
postgres (pid: 32200) =# CREATE TABLE mooncake_numeric_tbl_2 (val numeric(40, 5)) USING columnst
ore;
ERROR:  Unsupported type when creating column: type precision 40 with scale 5 is not supported by duckdb
postgres (pid: 32200) =# CREATE TABLE mooncake_numeric_tbl_2 (val numeric) USING columnstore;
ERROR:  Unsupported type when creating column: type precision 65535 with scale -5 is not supported by duckdb
postgres (pid: 32200) =# CREATE TABLE mooncake_numeric_tbl_2 (val numeric(38, 3)) USING columnst
ore;
CREATE TABLE
```