### PR TITLE
Explicitly link C++ standard library

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -26,7 +26,7 @@ PG_CPPFLAGS := -I../../src \
                -MMD -MP
 PG_CFLAGS := $(if $(DEBUG),-ggdb3 -O0,-O2)
 PG_CXXFLAGS := $(if $(DEBUG),-ggdb3 -O0,-O2) -Werror -Wno-register -Wno-sign-compare -std=c++17
-SHLIB_LINK := -L. -Wl,-rpath,$(PG_LIB) -lduckdb
+SHLIB_LINK := -L. -Wl,-rpath,$(PG_LIB) -lduckdb -lstdc++
 
 override with_llvm := no
 include $(PGXS)


### PR DESCRIPTION
#56 
```plpgsql
[postgres@halo-centos8 pg_mooncake]$ cat Makefile.build|grep SHLIB_LINK
SHLIB_LINK := -L. -Wl,-rpath,$(PG_LIB) -lduckdb -lstdc++
[postgres@halo-centos8 pg_mooncake]$ psql mooncake
psql (16.6)
Type "help" for help.

mooncake=# create extension pg_mooncake;
CREATE EXTENSION
mooncake=# 
``` 