### PR TITLE
Add --cap-add=SYS_PTRACE to runArgs for GDB debugging support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,8 @@
                 "rust-lang.rust-analyzer"
             ]
         }
-    }
+    },
+    "runArgs": [
+        "--cap-add=SYS_PTRACE"
+    ]
 }


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change adds the `--cap-add=SYS_PTRACE` argument to the `runArgs` configuration. 

This resolves potential permission issues when attaching gdb to the PostgreSQL process, as outlined [here](https://github.com/Microsoft/MIEngine/wiki/Troubleshoot-attaching-to-processes-using-GDB).