### PR TITLE
Only write to Delta Lake log when timeline_id matches

### DIFF
--- a/sql/pg_mooncake--0.0.1.sql
+++ b/sql/pg_mooncake--0.0.1.sql
@@ -7,7 +7,8 @@ CREATE SCHEMA mooncake;
 
 CREATE TABLE mooncake.tables (
     oid OID NOT NULL,
-    path TEXT NOT NULL
+    path TEXT NOT NULL,
+    timeline_id TEXT NOT NULL
 );
 CREATE UNIQUE INDEX tables_oid ON mooncake.tables (oid);
 

--- a/src/columnstore/columnstore_metadata.cpp
+++ b/src/columnstore/columnstore_metadata.cpp
@@ -31,7 +31,7 @@ Datum StringGetTextDatum(const string_t &s) {
     return PointerGetDatum(cstring_to_text_with_len(s.GetData(), s.GetSize()));
 }
 
-constexpr int x_tables_natts = 2;
+constexpr int x_tables_natts = 3;
 constexpr int x_data_files_natts = 3;
 constexpr int x_secrets_natts = 5;
 
@@ -62,8 +62,8 @@ Oid Secrets() {
 void ColumnstoreMetadata::TablesInsert(Oid oid, const string &path) {
     ::Relation table = table_open(Tables(), RowExclusiveLock);
     TupleDesc desc = RelationGetDescr(table);
-    Datum values[x_tables_natts] = {oid, StringGetTextDatum(path)};
-    bool nulls[x_tables_natts] = {false, false};
+    Datum values[x_tables_natts] = {oid, StringGetTextDatum(path), CStringGetTextDatum(mooncake_timeline_id)};
+    bool nulls[x_tables_natts] = {false, false, false};
     HeapTuple tuple = heap_form_tuple(desc, values, nulls);
     PostgresFunctionGuard(CatalogTupleInsert, table, tuple);
     CommandCounterIncrement();
@@ -88,7 +88,7 @@ void ColumnstoreMetadata::TablesDelete(Oid oid) {
     table_close(table, RowExclusiveLock);
 }
 
-string ColumnstoreMetadata::TablesSearch(Oid oid) {
+std::tuple<string /*path*/, string /*timeline_id*/> ColumnstoreMetadata::TablesSearch(Oid oid) {
     ::Relation table = table_open(Tables(), AccessShareLock);
     ::Relation index = index_open(TablesOid(), AccessShareLock);
     TupleDesc desc = RelationGetDescr(table);
@@ -97,18 +97,20 @@ string ColumnstoreMetadata::TablesSearch(Oid oid) {
     SysScanDesc scan = systable_beginscan_ordered(table, index, snapshot, 1 /*nkeys*/, key);
 
     string path;
+    string timeline_id;
     HeapTuple tuple;
     Datum values[x_tables_natts];
     bool isnull[x_tables_natts];
     if (HeapTupleIsValid(tuple = systable_getnext_ordered(scan, ForwardScanDirection))) {
         heap_deform_tuple(tuple, desc, values, isnull);
         path = TextDatumGetCString(values[1]);
+        timeline_id = TextDatumGetCString(values[2]);
     }
 
     systable_endscan_ordered(scan);
     index_close(index, AccessShareLock);
     table_close(table, AccessShareLock);
-    return path;
+    return {std::move(path), std::move(timeline_id)};
 }
 
 string ColumnstoreMetadata::GetTablePath(Oid oid) {
@@ -127,23 +129,20 @@ string ColumnstoreMetadata::GetTablePath(Oid oid) {
     return path;
 }
 
-void ColumnstoreMetadata::GetTableMetadata(Oid oid, string &table_name /*out*/, vector<string> &column_names /*out*/,
-                                           vector<string> &column_types /*out*/) {
-    D_ASSERT(column_names.empty());
-    D_ASSERT(column_types.empty());
-
+std::tuple<string /*table_name*/, vector<string> /*column_names*/, vector<string> /*column_types*/>
+ColumnstoreMetadata::GetTableMetadata(Oid oid) {
     ::Relation table = table_open(oid, AccessShareLock);
     TupleDesc desc = RelationGetDescr(table);
-    table_name = RelationGetRelationName(table);
-
-    column_names.reserve(desc->natts);
-    column_types.reserve(desc->natts);
+    string table_name = RelationGetRelationName(table);
+    vector<string> column_names(desc->natts);
+    vector<string> column_types(desc->natts);
     for (int i = 0; i < desc->natts; i++) {
         Form_pg_attribute attr = &desc->attrs[i];
         column_names.emplace_back(NameStr(attr->attname));
         column_types.emplace_back(format_type_be(attr->atttypid));
     }
     table_close(table, AccessShareLock);
+    return {std::move(table_name), std::move(column_names), std::move(column_types)};
 }
 
 void ColumnstoreMetadata::DataFilesInsert(Oid oid, const string &file_name, const string_t &file_metadata) {

--- a/src/columnstore/columnstore_metadata.hpp
+++ b/src/columnstore/columnstore_metadata.hpp
@@ -16,11 +16,11 @@ public:
 public:
     void TablesInsert(Oid oid, const string &path);
     void TablesDelete(Oid oid);
-    string TablesSearch(Oid oid);
+    std::tuple<string /*path*/, string /*timeline_id*/> TablesSearch(Oid oid);
 
     string GetTablePath(Oid oid);
-    void GetTableMetadata(Oid oid, string &table_name /*out*/, vector<string> &column_names /*out*/,
-                          vector<string> &column_types /*out*/);
+    std::tuple<string /*table_name*/, vector<string> /*column_names*/, vector<string> /*column_types*/>
+    GetTableMetadata(Oid oid);
 
     void DataFilesInsert(Oid oid, const string &file_name, const string_t &file_metadata);
     void DataFilesDelete(const string &file_name);

--- a/src/columnstore/columnstore_table.hpp
+++ b/src/columnstore/columnstore_table.hpp
@@ -39,6 +39,7 @@ private:
 private:
     Oid oid;
     unique_ptr<ColumnstoreMetadata> metadata;
+    string path;
     unique_ptr<ColumnstoreWriter> writer;
 };
 

--- a/src/columnstore/execution/columnstore_scan.cpp
+++ b/src/columnstore/execution/columnstore_scan.cpp
@@ -135,7 +135,6 @@ unique_ptr<GlobalTableFunctionState> ColumnstoreScanInitGlobal(ClientContext &co
 }
 
 TableFunction ColumnstoreTable::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
-    auto path = metadata->TablesSearch(oid);
     auto file_names = metadata->DataFilesSearch(oid, &context, &columns);
     auto file_paths = GetFilePaths(path, file_names);
     if (file_paths.empty()) {

--- a/src/pgmooncake.cpp
+++ b/src/pgmooncake.cpp
@@ -5,6 +5,7 @@ extern "C" {
 #include "postgres.h"
 
 #include "fmgr.h"
+#include "utils/guc.h"
 }
 
 void MooncakeInitGUC();
@@ -13,6 +14,7 @@ void DuckdbInitHooks();
 bool mooncake_allow_local_tables = true;
 char *mooncake_default_bucket = strdup("");
 bool mooncake_enable_local_cache = true;
+const char *mooncake_timeline_id = "main";
 
 extern "C" {
 PG_MODULE_MAGIC;
@@ -24,6 +26,12 @@ void _PG_init() {
     DuckdbInitHooks();
     DuckdbInitNode();
     pgduckdb::RegisterDuckdbXactCallback();
+
+    const char *neon_timeline_id =
+        GetConfigOption("neon.timeline_id", true /*missing_ok*/, false /*restrict_privileged*/);
+    if (neon_timeline_id) {
+        mooncake_timeline_id = neon_timeline_id;
+    }
 
     auto local_fs = duckdb::FileSystem::CreateLocal();
     local_fs->CreateDirectory("mooncake_local_cache");

--- a/src/pgmooncake.cpp
+++ b/src/pgmooncake.cpp
@@ -30,6 +30,7 @@ void _PG_init() {
     const char *neon_timeline_id =
         GetConfigOption("neon.timeline_id", true /*missing_ok*/, false /*restrict_privileged*/);
     if (neon_timeline_id) {
+        mooncake_allow_local_tables = false;
         mooncake_timeline_id = neon_timeline_id;
     }
 

--- a/src/pgmooncake_guc.hpp
+++ b/src/pgmooncake_guc.hpp
@@ -3,3 +3,4 @@
 extern bool mooncake_allow_local_tables;
 extern char *mooncake_default_bucket;
 extern bool mooncake_enable_local_cache;
+extern const char *mooncake_timeline_id;


### PR DESCRIPTION
On Neon, a table can exist in multiple branches, and allowing them to write to the same Delta Lake log is problematic. This is even worse that a branch can be reset to an earlier point of time. To fix this, we attach Delta Lake log to Neon's timeline, which is unique and only moves forward. Specifically, we persist `neon.timeline_id` when a columnstore table is created and only allow writing to the table's Delta Lake log if the current `neon.timeline_id` matches