### PR TITLE
Decrease file size to make seg elimination more efficient.

### DIFF
--- a/src/columnstore/columnstore_table.cpp
+++ b/src/columnstore/columnstore_table.cpp
@@ -95,8 +95,8 @@ public:
 
 private:
     static const idx_t x_row_group_size = duckdb::Storage::ROW_GROUP_SIZE;
-    static const idx_t x_row_group_size_bytes = x_row_group_size * 1024;
-    static const idx_t x_file_size_bytes = 1 << 30;
+    static const idx_t x_row_group_size_bytes = x_row_group_size * 512;
+    static const idx_t x_file_size_bytes = 1 << 28;
 
     SingleFileCachedWriteFileSystem fs;
     ColumnDataCollection collection;


### PR DESCRIPTION
File size is now 256MB instead of 1GB.