### PR TITLE
Add extension reload script

### DIFF
--- a/scripts/reload-extension.sh
+++ b/scripts/reload-extension.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "Building and installing the extension..."
+make debug -j$(nproc)
+if [ $? -ne 0 ]; then
+    echo "Failed to build the extension."
+    exit 1
+fi
+
+make install -j$(nproc)
+if [ $? -ne 0 ]; then
+    echo "Failed to install the extension."
+    exit 1
+fi
+echo "Extension built and installed successfully."
+
+PG_DATA_DIR="/usr/local/pgsql/data"
+
+echo "Restarting PostgreSQL..."
+pg_ctl -D "$PG_DATA_DIR" restart
+if [ $? -ne 0 ]; then
+    echo "Failed to restart PostgreSQL."
+    exit 1
+fi
+echo "PostgreSQL restarted successfully."
+
+echo "Reloading pg_mooncake extension..."
+psql -U postgres -c "DROP EXTENSION IF EXISTS pg_mooncake CASCADE;" &&
+psql -U postgres -c "CREATE EXTENSION pg_mooncake;"
+
+if [ $? -ne 0 ]; then
+    echo "Failed to reload pg_mooncake extension."
+    exit 1
+fi
+
+echo "pg_mooncake extension reloaded successfully."


### PR DESCRIPTION
Automate the process of reloading the extension for changes to take effect by:
- Building the extension with `make debug`
- Installing the extension
- Restarting PG
- Dropping the extension
- Creating the extension

Example usage:
```sh
./scripts/reload-extension.sh
```

Found this useful so thought I would share. Any other workflow automations can also be added here.