### PR TITLE
[DRAFT] Build on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,16 +46,16 @@ duckdb: | .BUILD
 	CMAKE_BUILD_PARALLEL_LEVEL=$(or $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS))),1) \
 	$(MAKE) -C third_party/duckdb $(BUILD_TYPE)
 ifeq ($(BUILD_TYPE), debug)
-	gdb-add-index third_party/duckdb/build/debug/src/libduckdb.so
+	gdb-add-index third_party/duckdb/build/debug/src/libduckdb.dylib
 endif
 
-duckdb-fast: third_party/duckdb/build/$(BUILD_TYPE)/src/libduckdb.so | .BUILD
-	install -C $< build/$(BUILD_TYPE)/libduckdb.so
+duckdb-fast: third_party/duckdb/build/$(BUILD_TYPE)/src/libduckdb.dylib | .BUILD
+	install -C $< build/$(BUILD_TYPE)/libduckdb.dylib
 
 clean-duckdb:
 	$(MAKE) -C third_party/duckdb clean
 
-third_party/duckdb/build/$(BUILD_TYPE)/src/libduckdb.so: | .BUILD
+third_party/duckdb/build/$(BUILD_TYPE)/src/libduckdb.dylib: | .BUILD
 	@$(MAKE) duckdb
 
 # Delta

--- a/Makefile.build
+++ b/Makefile.build
@@ -6,7 +6,7 @@ DATA := ../../sql/pg_mooncake--0.0.1.sql
 SRCS_C := $(shell cd ../../src; find * -name '*.c')
 SRCS_CXX := $(shell cd ../../src; find * -name '*.cpp')
 SRCS := $(SRCS_C) $(SRCS_CXX)
-OBJS := $(SRCS:%=%.o) libduckdb.so libdelta.a
+OBJS := $(SRCS:%=%.o) libduckdb.dylib libdelta.a
 DEPS := $(SRCS:%=%.d)
 
 REGRESS_SQL := $(shell cd ../../test/sql; find * -name '*.sql')
@@ -26,7 +26,14 @@ PG_CPPFLAGS := -I../../src \
                -MMD -MP
 PG_CFLAGS := $(if $(DEBUG),-ggdb3 -O0,-O2)
 PG_CXXFLAGS := $(if $(DEBUG),-ggdb3 -O0,-O2) -Werror -Wno-register -Wno-sign-compare -std=c++17
-SHLIB_LINK := -L. -Wl,-rpath,$(PG_LIB) -lduckdb
+
+
+LDFLAGS += -framework CoreFoundation -framework Security -llz4 -stdlib=libc++ -lc++
+
+SHLIB_LINK := -L. -Wl,-rpath,$(PG_LIB) -lduckdb $(LDFLAGS)
+CXXFLAGS := -Wno-overloaded-virtual
+
+
 
 override with_llvm := no
 include $(PGXS)
@@ -35,11 +42,11 @@ include $(PGXS)
 
 $(SRCS_C:%=%.o): %.o: ../../src/%
 	@mkdir -p $(dir $@)
-	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+	$(CC) $(CPPFLAGS) $(CFLAGS) -Wno-overloaded-virtual -stdlib=libc++ -c $< -o $@
 
 $(SRCS_CXX:%=%.o): %.o: ../../src/%
 	@mkdir -p $(dir $@)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -Wno-overloaded-virtual -stdlib=libc++ -c $< -o $@
 
 installcheck: installcheck-dirs
 

--- a/src/pgduckdb/utility/copy.cpp
+++ b/src/pgduckdb/utility/copy.cpp
@@ -24,9 +24,9 @@ extern "C" {
 #include "pgduckdb/vendor/pg_list.hpp"
 }
 
-static constexpr char s3_filename_prefix[] = "s3://";
-static constexpr char gcs_filename_prefix[] = "gs://";
-static constexpr char r2_filename_prefix[] = "r2://";
+// static constexpr char s3_filename_prefix[] = "s3://";
+// static constexpr char gcs_filename_prefix[] = "gs://";
+// static constexpr char r2_filename_prefix[] = "r2://";
 
 /*
  * Returns the relation of the copy_stmt as a fully qualified DuckDB table reference. This is done


### PR DESCRIPTION
Quite dirty and would break linux build, but shows what is missing for macOS build.

To build run `CXXFLAGS="-std=c++17 -Wno-overloaded-virtual" make release -j`.

`no-overloaded-virtual` is better to fix in the code itself.