### PR TITLE
Add initial implementation for deletion vectors

### DIFF
--- a/sql/pg_mooncake--0.1.0.sql
+++ b/sql/pg_mooncake--0.1.0.sql
@@ -20,6 +20,14 @@ CREATE TABLE mooncake.data_files (
 CREATE INDEX data_files_oid ON mooncake.data_files (oid);
 CREATE UNIQUE INDEX data_files_file_name ON mooncake.data_files (file_name);
 
+CREATE TABLE mooncake.deletion_vectors (
+    file_name TEXT NOT NULL,
+    chunk_idx BIGINT NOT NULL,
+    deletion_vector BYTEA NOT NULL
+);
+CREATE UNIQUE INDEX deletion_vectors_file_chunk ON mooncake.deletion_vectors (file_name, chunk_idx);
+
+
 CREATE FUNCTION mooncake.read_parquet(path text, binary_as_string BOOLEAN DEFAULT FALSE,
                                                    filename BOOLEAN DEFAULT FALSE,
                                                    file_row_number BOOLEAN DEFAULT FALSE,

--- a/src/columnstore/columnstore_deletion_vector.cpp
+++ b/src/columnstore/columnstore_deletion_vector.cpp
@@ -1,0 +1,33 @@
+#include "columnstore_deletion_vector.hpp"
+
+namespace duckdb {
+
+void DeletionVector::MarkDeleted(const idx_t offset) {
+    bitmap[offset] = true;
+}
+
+bool DeletionVector::IsDeleted(size_t row_id) const {
+    return row_id < bitmap.size() && bitmap[row_id];
+}
+
+std::string DeletionVector::Serialize(const DeletionVector &deletion_vector) {
+    std::string result(deletion_vector.bitmap.size(), '0');
+    for (size_t i = 0; i < deletion_vector.bitmap.size(); ++i) {
+        if (deletion_vector.bitmap[i]) {
+            result[i] = '1';
+        }
+    }
+    return result;
+}
+
+DeletionVector DeletionVector::Deserialize(const std::string &serialized) {
+    DeletionVector deletion_vector;
+    for (size_t i = 0; i < serialized.size(); ++i) {
+        if (serialized[i] == '1') {
+            deletion_vector.MarkDeleted(i);
+        }
+    }
+    return deletion_vector;
+}
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_deletion_vector.hpp
+++ b/src/columnstore/columnstore_deletion_vector.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "duckdb/common/types/uuid.hpp"
+#include "duckdb/common/vector_size.hpp"
+
+namespace duckdb {
+class DeletionVector {
+public:
+    DeletionVector() : bitmap(STANDARD_VECTOR_SIZE, false) {}
+
+    void MarkDeleted(const idx_t offset);
+    bool IsDeleted(size_t row_id) const;
+
+    size_t size() const {
+        return bitmap.size();
+    }
+
+    static std::string Serialize(const DeletionVector &deletion_vector);
+    static DeletionVector Deserialize(const std::string &serialized);
+
+private:
+    std::vector<bool> bitmap;
+};
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_table.hpp
+++ b/src/columnstore/columnstore_table.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "columnstore/deletion_vector_manager.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "pgduckdb/pg/declarations.hpp"
 

--- a/src/columnstore/deletion_vector_manager.cpp
+++ b/src/columnstore/deletion_vector_manager.cpp
@@ -1,0 +1,136 @@
+// dv_manager.cpp
+#include "deletion_vector_manager.hpp"
+#include "parquet_reader.hpp"
+#include "pgduckdb/pgduckdb_utils.hpp"
+#include "pgmooncake_guc.hpp"
+
+extern "C" {
+#include "postgres.h"
+
+#include "access/genam.h"
+#include "access/table.h"
+#include "access/xact.h"
+#include "catalog/indexing.h"
+#include "catalog/namespace.h"
+#include "commands/dbcommands.h"
+#include "miscadmin.h"
+#include "utils/builtins.h"
+#include "utils/fmgroids.h"
+#include "utils/lsyscache.h"
+#include "utils/rel.h"
+}
+
+namespace duckdb {
+
+namespace {
+
+Datum StringGetTextDatum(const string &s) {
+    return PointerGetDatum(cstring_to_text_with_len(s.data(), s.size()));
+}
+
+Oid Mooncake() {
+    return get_namespace_oid("mooncake", false /*missing_ok*/);
+}
+static Oid DeletionVectors() {
+    return get_relname_relid("deletion_vectors", Mooncake());
+}
+Oid DeletionVectorsFileGroupChunk() {
+    return get_relname_relid("deletion_vectors_file_chunk", Mooncake());
+}
+
+} // namespace
+
+void DVManager::UpsertDV(const std::string &file_name,
+                         uint64_t chunk_idx,
+                         const DeletionVector &deletion_vector) {
+    UpsertDVOperation op;
+    op.file_name = file_name;
+    op.chunk_idx = chunk_idx;
+    op.deletion_vector = deletion_vector;
+
+    upsert_operations_buffer.push_back(std::move(op));
+    if (upsert_operations_buffer.size() >= x_op_batch_size) {
+        Flush();
+    }
+}
+
+DeletionVector DVManager::FetchDV(const string &file_name, const uint64_t chunk_idx) {
+    ::Relation table = table_open(DeletionVectors(), AccessShareLock);
+    ::Relation index = index_open(DeletionVectorsFileGroupChunk(), AccessShareLock);
+    ScanKeyData key[2];
+    ScanKeyInit(&key[0], 1 /* attributeNumber */, BTEqualStrategyNumber, F_TEXTEQ, StringGetTextDatum(file_name));
+    ScanKeyInit(&key[1], 2 /* attributeNumber */, BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(chunk_idx));
+    SysScanDesc scan = systable_beginscan_ordered(table, index, snapshot, 2 /*nkeys*/, key);
+
+    string deletion_vector;
+    HeapTuple tuple;
+    Datum values[x_deletion_vectors_natts];
+    bool isnull[x_deletion_vectors_natts];
+    if (HeapTupleIsValid(tuple = systable_getnext_ordered(scan, ForwardScanDirection))) {
+        heap_deform_tuple(tuple, RelationGetDescr(table), values, isnull);
+        deletion_vector = TextDatumGetCString(values[2]);
+    }
+
+    systable_endscan_ordered(scan);
+    index_close(index, AccessShareLock);
+    table_close(table, AccessShareLock);
+
+    return DeletionVector::Deserialize(deletion_vector);
+}
+
+void DVManager::FlushUpsertDV()
+{
+    ::Relation table = table_open(DeletionVectors(), RowExclusiveLock);
+    ::Relation index = index_open(DeletionVectorsFileGroupChunk(), RowExclusiveLock);
+
+    for (auto &op : upsert_operations_buffer) {
+        DeleteDV(op, table, index, snapshot);
+        InsertDV(op, table);
+    }
+
+    index_close(index, RowExclusiveLock);
+    table_close(table, RowExclusiveLock);
+}
+
+void DVManager::DeleteDV(const UpsertDVOperation &op,
+                                 ::Relation table,
+                                 ::Relation index,
+                                 Snapshot snapshot)
+{
+    ScanKeyData key[2];
+    ScanKeyInit(&key[0],
+                1 /* attributeNumber */,
+                BTEqualStrategyNumber,
+                F_TEXTEQ,
+                StringGetTextDatum(op.file_name));
+    ScanKeyInit(&key[1],
+                2 /* attributeNumber */,
+                BTEqualStrategyNumber,
+                F_INT8EQ,
+                Int64GetDatum(op.chunk_idx));
+
+    SysScanDesc scan = systable_beginscan_ordered(table, index, snapshot, 2, key);
+    HeapTuple tuple = systable_getnext_ordered(scan, ForwardScanDirection);
+
+    if (HeapTupleIsValid(tuple)) {
+        PostgresFunctionGuard(CatalogTupleDelete, table, &tuple->t_self);
+    }
+    systable_endscan_ordered(scan);
+}
+
+void DVManager::InsertDV(const UpsertDVOperation &op, ::Relation table)
+{
+    bool nulls[x_deletion_vectors_natts] = {false, false, false};
+    Datum values[x_deletion_vectors_natts];
+
+    values[0] = StringGetTextDatum(op.file_name);
+    values[1] = Int64GetDatum(op.chunk_idx);
+    values[2] = StringGetTextDatum(DeletionVector::Serialize(op.deletion_vector));
+
+    HeapTuple new_tuple = heap_form_tuple(RelationGetDescr(table), values, nulls);
+    PostgresFunctionGuard(CatalogTupleInsert, table, new_tuple);
+    CommandCounterIncrement();
+}
+
+
+} // namespace duckdb

--- a/src/columnstore/deletion_vector_manager.cpp
+++ b/src/columnstore/deletion_vector_manager.cpp
@@ -40,9 +40,7 @@ Oid DeletionVectorsFileGroupChunk() {
 
 } // namespace
 
-void DVManager::UpsertDV(const std::string &file_name,
-                         uint64_t chunk_idx,
-                         const DeletionVector &deletion_vector) {
+void DVManager::UpsertDV(const std::string &file_name, uint64_t chunk_idx, const DeletionVector &deletion_vector) {
     UpsertDVOperation op;
     op.file_name = file_name;
     op.chunk_idx = chunk_idx;
@@ -78,8 +76,7 @@ DeletionVector DVManager::FetchDV(const string &file_name, const uint64_t chunk_
     return DeletionVector::Deserialize(deletion_vector);
 }
 
-void DVManager::FlushUpsertDV()
-{
+void DVManager::FlushUpsertDV() {
     ::Relation table = table_open(DeletionVectors(), RowExclusiveLock);
     ::Relation index = index_open(DeletionVectorsFileGroupChunk(), RowExclusiveLock);
 
@@ -92,22 +89,10 @@ void DVManager::FlushUpsertDV()
     table_close(table, RowExclusiveLock);
 }
 
-void DVManager::DeleteDV(const UpsertDVOperation &op,
-                                 ::Relation table,
-                                 ::Relation index,
-                                 Snapshot snapshot)
-{
+void DVManager::DeleteDV(const UpsertDVOperation &op, ::Relation table, ::Relation index, Snapshot snapshot) {
     ScanKeyData key[2];
-    ScanKeyInit(&key[0],
-                1 /* attributeNumber */,
-                BTEqualStrategyNumber,
-                F_TEXTEQ,
-                StringGetTextDatum(op.file_name));
-    ScanKeyInit(&key[1],
-                2 /* attributeNumber */,
-                BTEqualStrategyNumber,
-                F_INT8EQ,
-                Int64GetDatum(op.chunk_idx));
+    ScanKeyInit(&key[0], 1 /* attributeNumber */, BTEqualStrategyNumber, F_TEXTEQ, StringGetTextDatum(op.file_name));
+    ScanKeyInit(&key[1], 2 /* attributeNumber */, BTEqualStrategyNumber, F_INT8EQ, Int64GetDatum(op.chunk_idx));
 
     SysScanDesc scan = systable_beginscan_ordered(table, index, snapshot, 2, key);
     HeapTuple tuple = systable_getnext_ordered(scan, ForwardScanDirection);
@@ -118,8 +103,7 @@ void DVManager::DeleteDV(const UpsertDVOperation &op,
     systable_endscan_ordered(scan);
 }
 
-void DVManager::InsertDV(const UpsertDVOperation &op, ::Relation table)
-{
+void DVManager::InsertDV(const UpsertDVOperation &op, ::Relation table) {
     bool nulls[x_deletion_vectors_natts] = {false, false, false};
     Datum values[x_deletion_vectors_natts];
 
@@ -131,6 +115,5 @@ void DVManager::InsertDV(const UpsertDVOperation &op, ::Relation table)
     PostgresFunctionGuard(CatalogTupleInsert, table, new_tuple);
     CommandCounterIncrement();
 }
-
 
 } // namespace duckdb

--- a/src/columnstore/deletion_vector_manager.hpp
+++ b/src/columnstore/deletion_vector_manager.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "columnstore_deletion_vector.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/storage/storage_info.hpp"
+#include "pgduckdb/pg/declarations.hpp"
+
+namespace duckdb {
+
+constexpr int x_deletion_vectors_natts = 3;
+constexpr int x_op_batch_size = duckdb::Storage::ROW_GROUP_SIZE;
+
+struct UpsertDVOperation {
+    string file_name;
+    uint64_t chunk_idx;
+    DeletionVector deletion_vector;
+};
+
+class DVManager {
+public:
+    explicit DVManager(Snapshot snapshot) : snapshot(snapshot) {}
+
+    void UpsertDV(const std::string &file_name, uint64_t chunk_idx, const DeletionVector &deletion_vector);
+
+    DeletionVector FetchDV(const std::string &file_name, uint64_t chunk_idx);
+
+    void Flush() {
+        FlushUpsertDV();
+        upsert_operations_buffer.clear();
+    };
+
+private:
+    Snapshot snapshot;
+    std::vector<UpsertDVOperation> upsert_operations_buffer;
+
+    void FlushUpsertDV();
+    void DeleteDV(const UpsertDVOperation &op, ::Relation table, ::Relation index, Snapshot snapshot);
+    void InsertDV(const UpsertDVOperation &op, ::Relation table);
+};
+
+} // namespace duckdb

--- a/src/columnstore/execution/columnstore_update.cpp
+++ b/src/columnstore/execution/columnstore_update.cpp
@@ -102,6 +102,7 @@ public:
                               OperatorSinkFinalizeInput &input) const override {
         auto &gstate = input.global_state.Cast<ColumnstoreUpdateGlobalState>();
         table.Delete(context, gstate.row_ids);
+        table.FinalizeInsert();
         return SinkFinalizeType::READY;
     }
 

--- a/test/expected/sanity.out
+++ b/test/expected/sanity.out
@@ -4,16 +4,16 @@ INSERT INTO t VALUES (2, 'f'), (3, 'g'), (4, 'h');
 UPDATE t SET b = a + 1 WHERE a > 3;
 DELETE FROM t WHERE a < 3;
 INSERT INTO t SELECT 2, b FROM t WHERE a = 3;
-SELECT * FROM t;
+SELECT * FROM t ORDER BY a, b;
  a | b 
 ---+---
- 4 | 5
- 5 | 6
- 4 | 5
- 3 | c
- 3 | g
  2 | c
  2 | g
+ 3 | c
+ 3 | g
+ 4 | 5
+ 4 | 5
+ 5 | 6
 (7 rows)
 
 DROP TABLE t;

--- a/test/expected/update_delete_with_join.out
+++ b/test/expected/update_delete_with_join.out
@@ -3,7 +3,7 @@ INSERT INTO s VALUES (1, 123), (1, 456);
 CREATE TABLE t (c int, d int) USING columnstore;
 INSERT INTO t VALUES (1, 0), (2, 0);
 UPDATE t SET d = b FROM s WHERE c = a;
-SELECT * FROM t;
+SELECT * FROM t ORDER BY c;
  c |  d  
 ---+-----
  1 | 123
@@ -11,7 +11,7 @@ SELECT * FROM t;
 (2 rows)
 
 DELETE FROM t USING s WHERE c = a;
-SELECT * FROM t;
+SELECT * FROM t ORDER BY c;
  c | d 
 ---+---
  2 | 0

--- a/test/sql/sanity.sql
+++ b/test/sql/sanity.sql
@@ -4,7 +4,7 @@ INSERT INTO t VALUES (2, 'f'), (3, 'g'), (4, 'h');
 UPDATE t SET b = a + 1 WHERE a > 3;
 DELETE FROM t WHERE a < 3;
 INSERT INTO t SELECT 2, b FROM t WHERE a = 3;
-SELECT * FROM t;
+SELECT * FROM t ORDER BY a, b;
 DROP TABLE t;
 
 CREATE TABLE t (a int);

--- a/test/sql/update_delete_with_join.sql
+++ b/test/sql/update_delete_with_join.sql
@@ -5,9 +5,9 @@ CREATE TABLE t (c int, d int) USING columnstore;
 INSERT INTO t VALUES (1, 0), (2, 0);
 
 UPDATE t SET d = b FROM s WHERE c = a;
-SELECT * FROM t;
+SELECT * FROM t ORDER BY c;
 
 DELETE FROM t USING s WHERE c = a;
-SELECT * FROM t;
+SELECT * FROM t ORDER BY c;
 
 DROP TABLE s, t;


### PR DESCRIPTION
This pull request implements a Deletion Vector (DV) mechanism and integrates it into `DELETE`, `UPDATE`, and `SCAN` operations, providing a foundation for more efficient data handling than the original copy-on-write approach. 

This PR includes:

**New DV Schema:**

A dedicated schema for storing DVs at the chunk level in a temporary heap table.
Facilitates tracking deleted row offsets within chunks.

**DVManager Class:**

Manages fetching and batching of DV inserts/deletes.

**Updated Delete/Update/Scan Logic:**

Leverages DVs to mark rows as deleted instead of copying data.
Integrates seamlessly with scan operations to filter out “deleted” rows.
This design significantly streamlines row invalidation, ensuring that regular read operations see only valid tuples while deferring expensive copy or cleanup steps.

**Next Steps**

Move DV Storage: We currently store DVs in a heap table as a temporary solution. A more optimized storage layer is planned.
Implement Compaction: Future work will include a compaction step or mechanism to physically reclaim space.

Note: Currently marking as Draft since there are a few TODO's I have left. Still worth getting up for some initial review and discussion. 