### PR TITLE
Enable httpfs read cache by default

### DIFF
--- a/sql/pg_mooncake--0.1.0.sql
+++ b/sql/pg_mooncake--0.1.0.sql
@@ -387,3 +387,6 @@ GRANT USAGE ON SCHEMA mooncake TO PUBLIC;
 GRANT SELECT ON mooncake.secrets_table_seq TO PUBLIC;
 GRANT SELECT ON mooncake.columnstore_tables TO PUBLIC;
 GRANT SELECT ON mooncake.cloud_secrets TO PUBLIC;
+
+-- Enable read-cache for HTTP filesystem by default.
+SET httpfs.force_download=true;


### PR DESCRIPTION
As suggested [here](https://github.com/Mooncake-Labs/pg_mooncake/pull/79#discussion_r1924315620), this PR enables read-cache for http filesystem by default.

Context for this PR, so we could revisit later:
- Initial RFC for implementing our mooncake's own disk-based read-cache: https://github.com/Mooncake-Labs/pg_mooncake/discussions/69
- Initial implementation without state machine covered for failure case and cache file retention: https://github.com/Mooncake-Labs/pg_mooncake/pull/79

This PR simply enables read-cache within httpfs, and remove the current write cache in columnstore.

Pro:
- It's good enough for now, since all remote accesses goes through httpfs;
- Easiest implementation, and easy to enable / disable (which we doesn't have a switch to turn off for write cache now).

Con:
- It's based on the assumption that httpfs (three fs instance inside) is the single entry point for remote accesses; if we have other fs extension in the future, we should revisit our cache strategy.