### PR TITLE
Rewrite SQL UDF in C++

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -50,7 +50,7 @@ MODULES := libduckdb
 MODULE_big := $(EXTENSION_NAME)
 DATA := $(SQL_DIR)/pg_mooncake--0.1.0.sql \
         $(SQL_DIR)/pg_mooncake--0.1.0--0.1.1.sql \
-        $(SQL_DIR)/pg_mooncake--0.1.1--0.1.2.sql
+        $(SQL_DIR)/pg_mooncake--0.1.1--0.2.0.sql
 EXTENSION := ../../$(EXTENSION_NAME)
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 override with_llvm := no

--- a/Makefile.build
+++ b/Makefile.build
@@ -49,7 +49,8 @@ SHLIB_LINK := -L. -Wl,-rpath,$(PG_LIB_DIR) -lduckdb -lstdc++
 MODULES := libduckdb
 MODULE_big := $(EXTENSION_NAME)
 DATA := $(SQL_DIR)/pg_mooncake--0.1.0.sql \
-        $(SQL_DIR)/pg_mooncake--0.1.0--0.1.1.sql
+        $(SQL_DIR)/pg_mooncake--0.1.0--0.1.1.sql \
+        $(SQL_DIR)/pg_mooncake--0.1.1--0.1.2.sql
 EXTENSION := ../../$(EXTENSION_NAME)
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 override with_llvm := no

--- a/pg_mooncake.control
+++ b/pg_mooncake.control
@@ -1,4 +1,4 @@
 comment = 'Columnstore Table in Postgres'
-default_version = '0.1.2'
+default_version = '0.2.0'
 module_pathname = '$libdir/pg_mooncake'
 relocatable = true

--- a/pg_mooncake.control
+++ b/pg_mooncake.control
@@ -1,4 +1,4 @@
 comment = 'Columnstore Table in Postgres'
-default_version = '0.1.1'
+default_version = '0.1.2'
 module_pathname = '$libdir/pg_mooncake'
 relocatable = true

--- a/sql/pg_mooncake--0.1.1--0.1.2.sql
+++ b/sql/pg_mooncake--0.1.1--0.1.2.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE FUNCTION mooncake.create_secret(
+    name TEXT,
+    type TEXT,
+    key_id TEXT,
+    secret TEXT,
+    extra_params JSONB DEFAULT '{}'::JSONB
+)
+RETURNS VOID
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT;

--- a/sql/pg_mooncake--0.1.1--0.2.0.sql
+++ b/sql/pg_mooncake--0.1.1--0.2.0.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS mooncake.create_secret;
+
 CREATE OR REPLACE FUNCTION mooncake.create_secret(
     name TEXT,
     type TEXT,
@@ -6,5 +8,6 @@ CREATE OR REPLACE FUNCTION mooncake.create_secret(
     extra_params JSONB DEFAULT '{}'::JSONB
 )
 RETURNS VOID
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
+AS 'MODULE_PATHNAME', 'mooncake_create_secret'
+LANGUAGE C STRICT
+SECURITY DEFINER;

--- a/src/columnstore/columnstore_metadata.cpp
+++ b/src/columnstore/columnstore_metadata.cpp
@@ -302,4 +302,17 @@ string ColumnstoreMetadata::SecretsSearchDeltaOptions(const string &path) {
     return option;
 }
 
+void ColumnstoreMetadata::SecretsInsert(const string &name, const string &type, const string &scope,
+                                        const string &query, const string &options) {
+    ::Relation table = table_open(Secrets(), RowExclusiveLock);
+    TupleDesc desc = RelationGetDescr(table);
+    Datum values[x_secrets_natts] = {StringGetTextDatum(name), StringGetTextDatum(type), StringGetTextDatum(scope),
+                                     StringGetTextDatum(query), StringGetTextDatum(options)};
+    bool isnull[x_secrets_natts] = {false, false, false, false, false};
+    HeapTuple tuple = heap_form_tuple(desc, values, isnull);
+    PostgresFunctionGuard(CatalogTupleInsert, table, tuple);
+    CommandCounterIncrement();
+    table_close(table, RowExclusiveLock);
+}
+
 } // namespace duckdb

--- a/src/columnstore/columnstore_metadata.cpp
+++ b/src/columnstore/columnstore_metadata.cpp
@@ -56,6 +56,9 @@ Oid DataFilesFileName() {
 Oid Secrets() {
     return get_relname_relid("secrets", Mooncake());
 }
+Oid SecretsSeq() {
+    return get_relname_relid("secrets_table_seq", Mooncake());
+}
 
 } // namespace
 
@@ -311,6 +314,7 @@ void ColumnstoreMetadata::SecretsInsert(const string &name, const string &type, 
     bool isnull[x_secrets_natts] = {false, false, false, false, false};
     HeapTuple tuple = heap_form_tuple(desc, values, isnull);
     PostgresFunctionGuard(CatalogTupleInsert, table, tuple);
+    PostgresFunctionGuard(DirectFunctionCall1Coll, nextval_oid, InvalidOid, SecretsSeq());
     CommandCounterIncrement();
     table_close(table, RowExclusiveLock);
 }

--- a/src/columnstore/columnstore_metadata.hpp
+++ b/src/columnstore/columnstore_metadata.hpp
@@ -30,6 +30,8 @@ public:
 
     vector<string> SecretsGetDuckdbQueries();
     string SecretsSearchDeltaOptions(const string &path);
+    void SecretsInsert(const string &name, const string &type, const string &scope, const string &query,
+                       const string &options);
 
 private:
     Snapshot snapshot;

--- a/src/columnstore_functions.cpp
+++ b/src/columnstore_functions.cpp
@@ -1,4 +1,5 @@
-#include "duckdb.hpp"
+#include "columnstore/columnstore_metadata.hpp"
+#include "duckdb/common/error_data.hpp"
 #include <string>
 #include <unordered_set>
 
@@ -12,7 +13,7 @@ extern "C" {
 
 #include "pgduckdb/utility/cpp_wrapper.hpp"
 
-constexpr int x_secrets_natts = 5;
+namespace duckdb {
 
 std::string GetStringFromText(text *t) {
     std::string str_val(VARDATA_ANY(t), VARSIZE_ANY_EXHDR(t));
@@ -24,29 +25,24 @@ std::string GetStringFromJsonbValue(JsonbValue jval) {
     return str_val;
 }
 
-extern "C" {
-
-DECLARE_PG_FUNCTION(create_secret) {
-    const std::string name = GetStringFromText(PG_GETARG_TEXT_PP(0));
-    const std::string type = GetStringFromText(PG_GETARG_TEXT_PP(1));
-    const std::string key_id = GetStringFromText(PG_GETARG_TEXT_PP(2));
-    const std::string secret = GetStringFromText(PG_GETARG_TEXT_PP(3));
-    Jsonb *extra_params = PG_GETARG_JSONB_P(4);
-
-    static const std::unordered_set<std::string> allowed_keys = {"ENDPOINT", "REGION", "SCOPE", "URL_STYLE", "USE_SSL"};
-
+void CreateMooncakeSecret(const string &name, const string &type, const string &key_id, const string &secret,
+                          Jsonb *extra_params) {
+    ColumnstoreMetadata metadata(NULL /*snapshot*/);
     JsonbContainer *conatiner = &extra_params->root;
     JsonbIterator *it = JsonbIteratorInit(conatiner);
     JsonbValue key;
     JsonbIteratorToken ret;
+    static const std::unordered_set<std::string> allowed_keys = {"ENDPOINT", "REGION", "SCOPE", "URL_STYLE", "USE_SSL"};
 
     if (type == "S3") {
         while ((ret = JsonbIteratorNext(&it, &key, false)) != WJB_DONE) {
             if (ret == WJB_KEY) {
                 std::string key_str = GetStringFromJsonbValue(key);
                 if (allowed_keys.find(key_str) == allowed_keys.end()) {
-                    elog(ERROR, "Invalid extra parameter: %s\nAllowed parameters are ENDPOINT, REGION, SCOPE, URL_STYLE, USE_SSL.", \
-                                key_str.c_str());
+                    elog(ERROR,
+                         "Invalid extra parameter: %s\nAllowed parameters are ENDPOINT, REGION, SCOPE, URL_STYLE, "
+                         "USE_SSL.",
+                         key_str.c_str());
                 }
             }
         }
@@ -63,8 +59,7 @@ DECLARE_PG_FUNCTION(create_secret) {
         if (getKeyJsonValueFromContainer(conatiner, "ENDPOINT", 8, &val)) {
             std::string endpoint = GetStringFromJsonbValue(val);
             if (endpoint.find("://") != std::string::npos) {
-                elog(ERROR, "Invalid ENDPOINT format: %s\nUse domain name excluding http prefix", \
-                            endpoint.c_str());
+                elog(ERROR, "Invalid ENDPOINT format: %s\nUse domain name excluding http prefix", endpoint.c_str());
             }
             if (!endpoint.empty() && endpoint.substr(0, 9) != "s3express") {
                 delta_endpoint = use_ssl ? "https://" : "https:/";
@@ -75,8 +70,8 @@ DECLARE_PG_FUNCTION(create_secret) {
         if (getKeyJsonValueFromContainer(conatiner, "URL_STYLE", 9, &val)) {
             std::string url_style = GetStringFromJsonbValue(val);
             if (url_style != "path" && url_style != "vhost") {
-                elog(ERROR, "Invalid URL_STYLE: %s\nAllowed values for URL_STYLE are \"path\" or \"vhost\".", \
-                            url_style.c_str());
+                elog(ERROR, "Invalid URL_STYLE: %s\nAllowed values for URL_STYLE are \"path\" or \"vhost\".",
+                     url_style.c_str());
             }
         }
 
@@ -92,7 +87,7 @@ DECLARE_PG_FUNCTION(create_secret) {
         for (const auto &key : allowed_keys) {
             if (getKeyJsonValueFromContainer(conatiner, key.c_str(), key.length(), &val)) {
                 if (key == "USE_SSL") {
-                    duckdb_query += ", USE_SSL '" + std::string(use_ssl ? "TRUE" : "FALSE") + "'";   
+                    duckdb_query += ", USE_SSL '" + std::string(use_ssl ? "TRUE" : "FALSE") + "'";
                 } else {
                     duckdb_query += ", " + key + " '" + GetStringFromJsonbValue(val) + "'";
                 }
@@ -100,8 +95,8 @@ DECLARE_PG_FUNCTION(create_secret) {
         }
         duckdb_query += ");";
 
-        std::string delta_options = "{\"AWS_ACCESS_KEY_ID\": \"" + key_id + "\"" +
-                                    ", \"AWS_SECRET_ACCESS_KEY\": \"" + secret + "\"";
+        std::string delta_options =
+            "{\"AWS_ACCESS_KEY_ID\": \"" + key_id + "\"" + ", \"AWS_SECRET_ACCESS_KEY\": \"" + secret + "\"";
 
         if (delta_endpoint.length() > 0) {
             delta_options += ", \"AWS_ENDPOINT\": \"" + delta_endpoint + "\"";
@@ -123,26 +118,24 @@ DECLARE_PG_FUNCTION(create_secret) {
         }
         delta_options += "}";
 
-        SPI_connect();
-
-        Oid argtypes[x_secrets_natts] = {TEXTOID, TEXTOID, TEXTOID, TEXTOID, TEXTOID};
-        Datum values[x_secrets_natts] = {CStringGetTextDatum(name.c_str()), CStringGetTextDatum(type.c_str()),
-                                         CStringGetTextDatum(scope.c_str()), CStringGetTextDatum(duckdb_query.c_str()),
-                                         CStringGetTextDatum(delta_options.c_str())};
-        SPIPlanPtr plan = SPI_prepare(
-            "INSERT INTO mooncake.secrets (name, type, scope, duckdb_query, delta_options) VALUES ($1, $2, $3, $4, $5)",
-            5, argtypes);
-        if (plan == NULL) {
-            elog(ERROR, "SPI_prepare() failed when creating mooncake secrets.");
-        }
-
-        SPI_execute_plan(plan, values, NULL, false, 1);
-        SPI_execute("SELECT nextval('mooncake.secrets_table_seq')", false, 1);
-        SPI_finish();
+        metadata.SecretsInsert(name, type, scope, duckdb_query, delta_options);
     } else {
-        elog(ERROR, "Unsupported secret type: %s\n Only secrets of type S3 are supported.", \
-                    type.c_str());
+        elog(ERROR, "Unsupported secret type: %s\nOnly secrets of type S3 are supported.", type.c_str());
     }
+}
+
+} // namespace duckdb
+
+extern "C" {
+
+DECLARE_PG_FUNCTION(mooncake_create_secret) {
+    const std::string name = duckdb::GetStringFromText(PG_GETARG_TEXT_PP(0));
+    const std::string type = duckdb::GetStringFromText(PG_GETARG_TEXT_PP(1));
+    const std::string key_id = duckdb::GetStringFromText(PG_GETARG_TEXT_PP(2));
+    const std::string secret = duckdb::GetStringFromText(PG_GETARG_TEXT_PP(3));
+    Jsonb *extra_params = PG_GETARG_JSONB_P(4);
+
+    duckdb::CreateMooncakeSecret(name, type, key_id, secret, extra_params);
 
     PG_RETURN_VOID();
 }

--- a/src/columnstore_functions.cpp
+++ b/src/columnstore_functions.cpp
@@ -1,0 +1,149 @@
+#include "duckdb.hpp"
+#include <string>
+#include <unordered_set>
+
+extern "C" {
+#include "postgres.h"
+#include "executor/spi.h"
+#include "fmgr.h"
+#include "utils/builtins.h"
+#include "utils/jsonb.h"
+}
+
+#include "pgduckdb/utility/cpp_wrapper.hpp"
+
+constexpr int x_secrets_natts = 5;
+
+std::string GetStringFromText(text *t) {
+    std::string str_val(VARDATA_ANY(t), VARSIZE_ANY_EXHDR(t));
+    return str_val;
+}
+
+std::string GetStringFromJsonbValue(JsonbValue jval) {
+    std::string str_val(jval.val.string.val, jval.val.string.len);
+    return str_val;
+}
+
+extern "C" {
+
+DECLARE_PG_FUNCTION(create_secret) {
+    const std::string name = GetStringFromText(PG_GETARG_TEXT_PP(0));
+    const std::string type = GetStringFromText(PG_GETARG_TEXT_PP(1));
+    const std::string key_id = GetStringFromText(PG_GETARG_TEXT_PP(2));
+    const std::string secret = GetStringFromText(PG_GETARG_TEXT_PP(3));
+    Jsonb *extra_params = PG_GETARG_JSONB_P(4);
+
+    static const std::unordered_set<std::string> allowed_keys = {"ENDPOINT", "REGION", "SCOPE", "URL_STYLE", "USE_SSL"};
+
+    JsonbContainer *conatiner = &extra_params->root;
+    JsonbIterator *it = JsonbIteratorInit(conatiner);
+    JsonbValue key;
+    JsonbIteratorToken ret;
+
+    if (type == "S3") {
+        while ((ret = JsonbIteratorNext(&it, &key, false)) != WJB_DONE) {
+            if (ret == WJB_KEY) {
+                std::string key_str = GetStringFromJsonbValue(key);
+                if (allowed_keys.find(key_str) == allowed_keys.end()) {
+                    elog(ERROR, "Invalid extra parameter: %s\nAllowed parameters are ENDPOINT, REGION, SCOPE, URL_STYLE, USE_SSL.", \
+                                key_str.c_str());
+                }
+            }
+        }
+
+        bool use_ssl = true;
+        std::string delta_endpoint;
+        JsonbValue val;
+
+        if (getKeyJsonValueFromContainer(conatiner, "USE_SSL", 7, &val)) {
+            std::string ssl_val = GetStringFromJsonbValue(val);
+            use_ssl = !(ssl_val == "FALSE" || ssl_val == "false");
+        }
+
+        if (getKeyJsonValueFromContainer(conatiner, "ENDPOINT", 8, &val)) {
+            std::string endpoint = GetStringFromJsonbValue(val);
+            if (endpoint.find("://") != std::string::npos) {
+                elog(ERROR, "Invalid ENDPOINT format: %s\nUse domain name excluding http prefix", \
+                            endpoint.c_str());
+            }
+            if (!endpoint.empty() && endpoint.substr(0, 9) != "s3express") {
+                delta_endpoint = use_ssl ? "https://" : "https:/";
+                delta_endpoint += endpoint;
+            }
+        }
+
+        if (getKeyJsonValueFromContainer(conatiner, "URL_STYLE", 9, &val)) {
+            std::string url_style = GetStringFromJsonbValue(val);
+            if (url_style != "path" && url_style != "vhost") {
+                elog(ERROR, "Invalid URL_STYLE: %s\nAllowed values for URL_STYLE are \"path\" or \"vhost\".", \
+                            url_style.c_str());
+            }
+        }
+
+        std::string scope;
+        if (getKeyJsonValueFromContainer(conatiner, "SCOPE", 5, &val)) {
+            scope = GetStringFromJsonbValue(val);
+        }
+
+        std::string duckdb_query = "CREATE SECRET \"duckdb_secret_" + name + "\" (TYPE " + type + ", KEY_ID '" +
+                                   key_id + "', SECRET '" + secret + "'";
+
+        // "ENDPOINT", "REGION", "SCOPE", "URL_STYLE", "USE_SSL"
+        for (const auto &key : allowed_keys) {
+            if (getKeyJsonValueFromContainer(conatiner, key.c_str(), key.length(), &val)) {
+                if (key == "USE_SSL") {
+                    duckdb_query += ", USE_SSL '" + std::string(use_ssl ? "TRUE" : "FALSE") + "'";   
+                } else {
+                    duckdb_query += ", " + key + " '" + GetStringFromJsonbValue(val) + "'";
+                }
+            }
+        }
+        duckdb_query += ");";
+
+        std::string delta_options = "{\"AWS_ACCESS_KEY_ID\": \"" + key_id + "\"" +
+                                    ", \"AWS_SECRET_ACCESS_KEY\": \"" + secret + "\"";
+
+        if (delta_endpoint.length() > 0) {
+            delta_options += ", \"AWS_ENDPOINT\": \"" + delta_endpoint + "\"";
+        }
+
+        if (getKeyJsonValueFromContainer(conatiner, "REGION", 6, &val)) {
+            delta_options += ", \"AWS_REGION\": \"" + GetStringFromJsonbValue(val) + "\"";
+        }
+
+        if (getKeyJsonValueFromContainer(conatiner, "USE_SSL", 7, &val)) {
+            delta_options += ", \"ALLOW_HTTP\": \"" + std::string(use_ssl ? "false" : "true") + "\"";
+        }
+
+        if (getKeyJsonValueFromContainer(conatiner, "ENDPOINT", 8, &val)) {
+            std::string endpoint = GetStringFromJsonbValue(val);
+            if (!endpoint.empty() && endpoint.substr(0, 9) == "s3express") {
+                delta_options += ", \"AWS_S3_EXPRESS\": \"true\"";
+            }
+        }
+        delta_options += "}";
+
+        SPI_connect();
+
+        Oid argtypes[x_secrets_natts] = {TEXTOID, TEXTOID, TEXTOID, TEXTOID, TEXTOID};
+        Datum values[x_secrets_natts] = {CStringGetTextDatum(name.c_str()), CStringGetTextDatum(type.c_str()),
+                                         CStringGetTextDatum(scope.c_str()), CStringGetTextDatum(duckdb_query.c_str()),
+                                         CStringGetTextDatum(delta_options.c_str())};
+        SPIPlanPtr plan = SPI_prepare(
+            "INSERT INTO mooncake.secrets (name, type, scope, duckdb_query, delta_options) VALUES ($1, $2, $3, $4, $5)",
+            5, argtypes);
+        if (plan == NULL) {
+            elog(ERROR, "SPI_prepare() failed when creating mooncake secrets.");
+        }
+
+        SPI_execute_plan(plan, values, NULL, false, 1);
+        SPI_execute("SELECT nextval('mooncake.secrets_table_seq')", false, 1);
+        SPI_finish();
+    } else {
+        elog(ERROR, "Unsupported secret type: %s\n Only secrets of type S3 are supported.", \
+                    type.c_str());
+    }
+
+    PG_RETURN_VOID();
+}
+} // extern C

--- a/test/expected/create_secret.out
+++ b/test/expected/create_secret.out
@@ -1,0 +1,51 @@
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+ create_secret 
+---------------
+ 
+(1 row)
+
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "SCOPE":"s3://mooncakebucket/folder"}');
+ create_secret 
+---------------
+ 
+(1 row)
+
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "USE_SSL":"FALSE"}');
+ create_secret 
+---------------
+ 
+(1 row)
+
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "URL_STYLE":"path"}');
+ create_secret 
+---------------
+ 
+(1 row)
+
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3express-use1-az6.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+ create_secret 
+---------------
+ 
+(1 row)
+
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "URL":"path"}');
+ERROR:  Invalid extra parameter: URL
+Allowed parameters are ENDPOINT, REGION, SCOPE, URL_STYLE, USE_SSL.
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"https://s3.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+ERROR:  Invalid ENDPOINT format: https://s3.us-east-1.amazonaws.com
+Use domain name excluding http prefix
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "URL_STYLE":"xpath"}');
+ERROR:  Invalid URL_STYLE: xpath
+Allowed values for URL_STYLE are "path" or "vhost".
+TRUNCATE TABLE mooncake.secrets;
+SELECT mooncake.create_secret('mooncake-test-secret', 'XYZ', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+ERROR:  Unsupported secret type: XYZ
+Only secrets of type S3 are supported.
+TRUNCATE TABLE mooncake.secrets;

--- a/test/sql/create_secret.sql
+++ b/test/sql/create_secret.sql
@@ -1,0 +1,26 @@
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "SCOPE":"s3://mooncakebucket/folder"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "USE_SSL":"FALSE"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "URL_STYLE":"path"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3express-use1-az6.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "URL":"path"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"https://s3.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'S3', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1", "URL_STYLE":"xpath"}');
+TRUNCATE TABLE mooncake.secrets;
+
+SELECT mooncake.create_secret('mooncake-test-secret', 'XYZ', 'ASDfExaMPLEKeyID', 'ASDfExaMPLESECRET', '{"ENDPOINT":"s3.us-east-1.amazonaws.com", "REGION":"us-east-1"}');
+TRUNCATE TABLE mooncake.secrets;


### PR DESCRIPTION
- Rewrite of SQL UDF `create_secret` in C++ for better maintainability. 
- This also PR introduces the `URL_STYLE` parameter (`path` or `vhost`) in create_secret to specify the S3 URL style.

fixes #37 