### PR TITLE
Add sshd to .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,5 +14,10 @@
     },
     "runArgs": [
         "--cap-add=SYS_PTRACE"
-    ]
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/sshd:1": {
+            "version": "latest"
+        }
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,6 @@
         "--cap-add=SYS_PTRACE"
     ],
     "features": {
-        "ghcr.io/devcontainers/features/sshd:1": {
-            "version": "latest"
-        }
+        "ghcr.io/devcontainers/features/sshd:1": {}
     }
 }


### PR DESCRIPTION
Adds the ability to SSH into codespaces container using the [SSHD dev container feature](https://github.com/devcontainers/features/tree/main/src/sshd).

Currently, trying to ssh into codespaces via `gh codespace ssh -c <my-container>` results in 

```
error getting ssh server details: failed to start SSH server:
Please check if an SSH server is installed in the container.
If the docker image being used for the codespace does not have an SSH server,
install it in your Dockerfile or, for codespaces that use Debian-based images,
you can add the following to your devcontainer.json:

"features": {
    "ghcr.io/devcontainers/features/sshd:1": {
        "version": "latest"
    }
}
```