### PR TITLE
Add sccache

### DIFF
--- a/.devcontainer/Dockerfile_17
+++ b/.devcontainer/Dockerfile_17
@@ -32,6 +32,8 @@ WORKDIR /home/postgres
 RUN echo 'source /workspaces/pg_mooncake/.devcontainer/.bashrc' >> .bashrc
 
 RUN curl https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/postgres/.cargo/bin:${PATH}"
+RUN cargo install sccache
 
 ENV PATH="/usr/local/pgsql/bin:${PATH}"
 RUN curl https://ftp.postgresql.org/pub/source/v17.2/postgresql-17.2.tar.bz2 | bzip2 -d | tar x \

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ $(DUCKDB_LIB): | .BUILD
 # Delta Targets
 # ========================
 delta: | .BUILD $(BUILD_RUST_DIR)
-	cargo build --manifest-path=$(DELTA_DIR)/Cargo.toml $(CARGO_FLAGS)
+	RUSTC_WRAPPER=sccache cargo build --manifest-path=$(DELTA_DIR)/Cargo.toml $(CARGO_FLAGS)
 	install -C $$(readlink -f $(DELTA_HEADER)) $(BUILD_RUST_DIR)/delta.hpp
 	install -C $(DELTA_LIB) $(BUILD_DIR)/libdelta.a
 

--- a/Makefile.build
+++ b/Makefile.build
@@ -32,6 +32,8 @@ REGRESS_OPTS = --inputdir=$(TEST_DIR) --load-extension=$(EXTENSION_NAME)
 # ========================
 # Compilation Flags
 # ========================
+override CC := sccache $(or $(CC),gcc)
+override CXX := sccache $(or $(CXX),g++)
 PG_CPPFLAGS := -I$(SRC_DIR) \
                -I$(DUCKDB_DIR)/extension/parquet/include \
                -I$(DUCKDB_DIR)/src/include \


### PR DESCRIPTION
Introduces [sccache](https://github.com/mozilla/sccache) integration to cache compiled artifacts for both C, C++ and Rust. Repeated builds become substantially faster—especially in clean builds or when switching branches.