### PR TITLE
retrieve correct cardinality for columnstore scan

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -27,7 +27,7 @@ DEPS := $(SRCS:%=%.d)
 # ========================
 REGRESS_SQL := $(shell cd $(TEST_DIR)/sql; find * -name '*.sql')
 REGRESS := $(REGRESS_SQL:%.sql=%)
-REGRESS_OPTS = --inputdir=$(TEST_DIR) --load-extension=$(EXTENSION_NAME)
+REGRESS_OPTS = --encoding=UTF8 --inputdir=$(TEST_DIR) --load-extension=$(EXTENSION_NAME)
 
 # ========================
 # Compilation Flags

--- a/src/columnstore/columnstore_statistics.cpp
+++ b/src/columnstore/columnstore_statistics.cpp
@@ -4,6 +4,7 @@
 namespace duckdb {
 
 DataFileStatistics::DataFileStatistics(ParquetReader &reader, const ColumnList &columns) {
+    num_rows = reader.NumRows();
     for (auto &col : columns.Physical()) {
         auto name = col.GetName();
         column_stats[name] = reader.ReadStatistics(name);

--- a/src/columnstore/columnstore_statistics.cpp
+++ b/src/columnstore/columnstore_statistics.cpp
@@ -3,8 +3,7 @@
 
 namespace duckdb {
 
-DataFileStatistics::DataFileStatistics(ParquetReader &reader, const ColumnList &columns) {
-    num_rows = reader.NumRows();
+DataFileStatistics::DataFileStatistics(ParquetReader &reader, const ColumnList &columns) : num_rows(reader.NumRows()) {
     for (auto &col : columns.Physical()) {
         auto name = col.GetName();
         column_stats[name] = reader.ReadStatistics(name);

--- a/src/columnstore/columnstore_statistics.hpp
+++ b/src/columnstore/columnstore_statistics.hpp
@@ -22,12 +22,12 @@ public:
         return ObjectType();
     }
 
-    BaseStatistics *Get(const string &name) {
-        return column_stats.at(name).get();
-    }
-
     idx_t NumRows() {
         return num_rows;
+    }
+
+    BaseStatistics *Get(const string &name) {
+        return column_stats.at(name).get();
     }
 
 private:

--- a/src/columnstore/columnstore_statistics.hpp
+++ b/src/columnstore/columnstore_statistics.hpp
@@ -26,7 +26,12 @@ public:
         return column_stats.at(name).get();
     }
 
+    idx_t NumRows() {
+        return num_rows;
+    }
+
 private:
+    idx_t num_rows;
     unordered_map<string, unique_ptr<BaseStatistics>> column_stats;
 };
 

--- a/src/columnstore/columnstore_table.cpp
+++ b/src/columnstore/columnstore_table.cpp
@@ -1,5 +1,6 @@
 #include "columnstore/columnstore_table.hpp"
 #include "columnstore/columnstore_metadata.hpp"
+#include "columnstore/columnstore_statistics.hpp"
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/common/types/uuid.hpp"
 #include "duckdb/parser/constraints/not_null_constraint.hpp"
@@ -278,6 +279,17 @@ vector<string> ColumnstoreTable::GetFilePaths(const string &path, const vector<s
         }
     }
     return file_paths;
+}
+
+idx_t ColumnstoreTable::Cardinality(const vector<string> &file_names) {
+    idx_t cardinality = 0;
+    for (auto &file_name : file_names) {
+        auto file_stats = columnstore_stats.Get<DataFileStatistics>(file_name);
+        if (file_stats) {
+            cardinality += file_stats->NumRows();
+        }
+    }
+    return cardinality;
 }
 
 } // namespace duckdb

--- a/src/columnstore/columnstore_table.cpp
+++ b/src/columnstore/columnstore_table.cpp
@@ -285,9 +285,8 @@ idx_t ColumnstoreTable::Cardinality(const vector<string> &file_names) {
     idx_t cardinality = 0;
     for (auto &file_name : file_names) {
         auto file_stats = columnstore_stats.Get<DataFileStatistics>(file_name);
-        if (file_stats) {
-            cardinality += file_stats->NumRows();
-        }
+        D_ASSERT(file_stats);
+        cardinality += file_stats->NumRows();
     }
     return cardinality;
 }

--- a/src/columnstore/columnstore_table.hpp
+++ b/src/columnstore/columnstore_table.hpp
@@ -38,6 +38,8 @@ public:
 private:
     vector<string> GetFilePaths(const string &path, const vector<string> &file_names);
 
+    idx_t Cardinality(const vector<string> &file_names);
+
 private:
     Oid oid;
     unique_ptr<ColumnstoreMetadata> metadata;

--- a/src/columnstore/columnstore_table.hpp
+++ b/src/columnstore/columnstore_table.hpp
@@ -38,7 +38,7 @@ public:
 private:
     vector<string> GetFilePaths(const string &path, const vector<string> &file_names);
 
-    idx_t Cardinality(const vector<string> &file_names);
+    static idx_t Cardinality(const vector<string> &file_names);
 
 private:
     Oid oid;

--- a/src/columnstore/columnstore_table.hpp
+++ b/src/columnstore/columnstore_table.hpp
@@ -36,7 +36,7 @@ public:
                 ColumnDataCollection *return_collection = nullptr);
 
 private:
-    vector<string> GetFilePaths(const string &path, const vector<string> &file_names);
+    static vector<string> GetFilePaths(const string &path, const vector<string> &file_names);
 
     static idx_t Cardinality(const vector<string> &file_names);
 

--- a/src/columnstore/execution/columnstore_scan.cpp
+++ b/src/columnstore/execution/columnstore_scan.cpp
@@ -153,11 +153,8 @@ TableFunction ColumnstoreTable::GetScanFunction(ClientContext &context, unique_p
     }
     vector<Value> inputs;
     inputs.push_back(Value::LIST(values));
-    idx_t carinality = Cardinality(file_names);
-    named_parameter_map_t named_parameters{{"file_row_number", Value(true)}};
-    if (carinality > 0) {
-        named_parameters["explicit_cardinality"] = Value::UBIGINT(carinality);
-    }
+    named_parameter_map_t named_parameters{{"file_row_number", Value(true)},
+                                           {"explicit_cardinality", Value::UBIGINT(Cardinality(file_names))}};
     vector<LogicalType> input_table_types;
     vector<string> input_table_names;
     TableFunctionBindInput bind_input(inputs, named_parameters, input_table_types, input_table_names, nullptr /*info*/,

--- a/src/columnstore/execution/columnstore_scan.cpp
+++ b/src/columnstore/execution/columnstore_scan.cpp
@@ -153,7 +153,11 @@ TableFunction ColumnstoreTable::GetScanFunction(ClientContext &context, unique_p
     }
     vector<Value> inputs;
     inputs.push_back(Value::LIST(values));
+    idx_t carinality = Cardinality(file_names);
     named_parameter_map_t named_parameters{{"file_row_number", Value(true)}};
+    if (carinality > 0) {
+        named_parameters["explicit_cardinality"] = Value::UBIGINT(carinality);
+    }
     vector<LogicalType> input_table_types;
     vector<string> input_table_names;
     TableFunctionBindInput bind_input(inputs, named_parameters, input_table_types, input_table_names, nullptr /*info*/,

--- a/test/expected/cardinality.out
+++ b/test/expected/cardinality.out
@@ -1,0 +1,86 @@
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT i FROM generate_series(1, 100) i;
+EXPLAIN SELECT * FROM t;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (MooncakeDuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │     COLUMNSTORE_SCAN      │
+ │    ────────────────────   │
+ │         Function:         │
+ │      COLUMNSTORE_SCAN     │
+ │                           │
+ │       Projections: a      │
+ │                           │
+ │         ~100 Rows         │
+ └───────────────────────────┘
+ 
+ 
+(15 rows)
+
+INSERT INTO t SELECT i FROM generate_series(1, 200) i;
+EXPLAIN SELECT * FROM t;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (MooncakeDuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │     COLUMNSTORE_SCAN      │
+ │    ────────────────────   │
+ │         Function:         │
+ │      COLUMNSTORE_SCAN     │
+ │                           │
+ │       Projections: a      │
+ │                           │
+ │         ~300 Rows         │
+ └───────────────────────────┘
+ 
+ 
+(15 rows)
+
+INSERT INTO t SELECT i FROM generate_series(1, 400) i;
+EXPLAIN SELECT * FROM t;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (MooncakeDuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │     COLUMNSTORE_SCAN      │
+ │    ────────────────────   │
+ │         Function:         │
+ │      COLUMNSTORE_SCAN     │
+ │                           │
+ │       Projections: a      │
+ │                           │
+ │         ~700 Rows         │
+ └───────────────────────────┘
+ 
+ 
+(15 rows)
+
+INSERT INTO t SELECT i FROM generate_series(1, 800) i;
+EXPLAIN SELECT * FROM t;
+                             QUERY PLAN                             
+--------------------------------------------------------------------
+ Custom Scan (MooncakeDuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
+   DuckDB Execution Plan: 
+ 
+ ┌───────────────────────────┐
+ │     COLUMNSTORE_SCAN      │
+ │    ────────────────────   │
+ │         Function:         │
+ │      COLUMNSTORE_SCAN     │
+ │                           │
+ │       Projections: a      │
+ │                           │
+ │         ~1500 Rows        │
+ └───────────────────────────┘
+ 
+ 
+(15 rows)
+
+DROP TABLE t;

--- a/test/expected/cardinality.out
+++ b/test/expected/cardinality.out
@@ -1,5 +1,5 @@
 CREATE TABLE t (a int) USING columnstore;
-INSERT INTO t SELECT i FROM generate_series(1, 100) i;
+INSERT INTO t SELECT * FROM generate_series(1, 100);
 EXPLAIN SELECT * FROM t;
                              QUERY PLAN                             
 --------------------------------------------------------------------
@@ -20,7 +20,7 @@ EXPLAIN SELECT * FROM t;
  
 (15 rows)
 
-INSERT INTO t SELECT i FROM generate_series(1, 200) i;
+INSERT INTO t SELECT * FROM generate_series(1, 200);
 EXPLAIN SELECT * FROM t;
                              QUERY PLAN                             
 --------------------------------------------------------------------
@@ -36,48 +36,6 @@ EXPLAIN SELECT * FROM t;
  │       Projections: a      │
  │                           │
  │         ~300 Rows         │
- └───────────────────────────┘
- 
- 
-(15 rows)
-
-INSERT INTO t SELECT i FROM generate_series(1, 400) i;
-EXPLAIN SELECT * FROM t;
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Custom Scan (MooncakeDuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
-   DuckDB Execution Plan: 
- 
- ┌───────────────────────────┐
- │     COLUMNSTORE_SCAN      │
- │    ────────────────────   │
- │         Function:         │
- │      COLUMNSTORE_SCAN     │
- │                           │
- │       Projections: a      │
- │                           │
- │         ~700 Rows         │
- └───────────────────────────┘
- 
- 
-(15 rows)
-
-INSERT INTO t SELECT i FROM generate_series(1, 800) i;
-EXPLAIN SELECT * FROM t;
-                             QUERY PLAN                             
---------------------------------------------------------------------
- Custom Scan (MooncakeDuckDBScan)  (cost=0.00..0.00 rows=0 width=0)
-   DuckDB Execution Plan: 
- 
- ┌───────────────────────────┐
- │     COLUMNSTORE_SCAN      │
- │    ────────────────────   │
- │         Function:         │
- │      COLUMNSTORE_SCAN     │
- │                           │
- │       Projections: a      │
- │                           │
- │         ~1500 Rows        │
  └───────────────────────────┘
  
  

--- a/test/sql/cardinality.sql
+++ b/test/sql/cardinality.sql
@@ -1,10 +1,6 @@
 CREATE TABLE t (a int) USING columnstore;
-INSERT INTO t SELECT i FROM generate_series(1, 100) i;
+INSERT INTO t SELECT * FROM generate_series(1, 100);
 EXPLAIN SELECT * FROM t;
-INSERT INTO t SELECT i FROM generate_series(1, 200) i;
-EXPLAIN SELECT * FROM t;
-INSERT INTO t SELECT i FROM generate_series(1, 400) i;
-EXPLAIN SELECT * FROM t;
-INSERT INTO t SELECT i FROM generate_series(1, 800) i;
+INSERT INTO t SELECT * FROM generate_series(1, 200);
 EXPLAIN SELECT * FROM t;
 DROP TABLE t;

--- a/test/sql/cardinality.sql
+++ b/test/sql/cardinality.sql
@@ -1,0 +1,10 @@
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT i FROM generate_series(1, 100) i;
+EXPLAIN SELECT * FROM t;
+INSERT INTO t SELECT i FROM generate_series(1, 200) i;
+EXPLAIN SELECT * FROM t;
+INSERT INTO t SELECT i FROM generate_series(1, 400) i;
+EXPLAIN SELECT * FROM t;
+INSERT INTO t SELECT i FROM generate_series(1, 800) i;
+EXPLAIN SELECT * FROM t;
+DROP TABLE t;


### PR DESCRIPTION
Compute cardinality from file metadata when initialize the columnstore scan, to ensure duckdb generates an optimal query plan.

fix #124 