### PR TITLE
Track and Delete dead data files in sync when dropping table

### DIFF
--- a/sql/pg_mooncake--0.1.1--0.1.2.sql
+++ b/sql/pg_mooncake--0.1.1--0.1.2.sql
@@ -1,0 +1,7 @@
+CREATE TABLE mooncake.dead_data_files (
+    oid OID NOT NULL,
+    file_name TEXT NOT NULL,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX dead_data_files_oid ON mooncake.dead_data_files (oid);
+CREATE UNIQUE INDEX dead_data_files_file_name ON mooncake.dead_data_files (file_name);

--- a/src/columnstore/columnstore.hpp
+++ b/src/columnstore/columnstore.hpp
@@ -17,6 +17,11 @@ public:
 
     static void TruncateTable(Oid oid);
 
+    // Caller must ensure that the table is a columnstore table.
+    // - oid: relation oid
+    // - flags: PERFORM_DELETION_xxx defined in dependency.h
+    static void DropTable(Oid oid, int flags);
+
     static void Abort();
 
     static void Commit();

--- a/src/columnstore/columnstore_metadata.hpp
+++ b/src/columnstore/columnstore_metadata.hpp
@@ -27,6 +27,7 @@ public:
     void DataFilesDelete(Oid oid);
     vector<string> DataFilesSearch(Oid oid, ClientContext *context = nullptr, const string *path = nullptr,
                                    const ColumnList *columns = nullptr);
+    vector<string> DeadDataFilesSearch(Oid oid);
 
     vector<string> SecretsGetDuckdbQueries();
     string SecretsSearchDeltaOptions(const string &path);

--- a/src/columnstore/columnstore_storage.cpp
+++ b/src/columnstore/columnstore_storage.cpp
@@ -1,0 +1,139 @@
+#include "columnstore/columnstore_storage.hpp"
+#include "columnstore/columnstore_metadata.hpp"
+#include "columnstore/columnstore_table.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/parallel/task_executor.hpp"
+
+#include "pgduckdb/logger.hpp"
+#include "pgduckdb/pg/transactions.hpp"
+
+namespace duckdb {
+
+class TransactionGuard {
+public:
+    TransactionGuard() {
+        auto &context = *pgduckdb::DuckDBManager::GetConnectionUnsafe()->context;
+        if (!context.transaction.HasActiveTransaction()) {
+            context.transaction.BeginTransaction();
+            require_new_transaction = true;
+        }
+    }
+    ~TransactionGuard() {
+        if (require_new_transaction) {
+            auto &context = *pgduckdb::DuckDBManager::GetConnectionUnsafe()->context;
+            context.transaction.Commit();
+        }
+    }
+
+private:
+    bool require_new_transaction = false;
+};
+
+class FileDeleteTask : public BaseExecutorTask {
+public:
+    FileDeleteTask(TaskExecutor &executor, FileSystem &fs, const string &path, atomic<bool> &success)
+        : BaseExecutorTask(executor), fs(fs), path(path), success(success) {}
+
+    void ExecuteTask() override {
+        try {
+            pd_log(DEBUG1, "Deleting file: %s", path.c_str());
+            fs.RemoveFile(path);
+        } catch (IOException &e) {
+            std::string_view errmsg(e.what());
+            // Ignore ENOENT exception
+            if (errmsg.find("No such file or directory") == string::npos) {
+                pd_log(WARNING, "Failed to delete file: %s", e.what());
+                success = false;
+            }
+        } catch (std::exception &e) {
+            pd_log(WARNING, "Failed to delete file: %s", e.what());
+            success = false;
+        }
+    }
+
+private:
+    FileSystem &fs;
+    const string &path;
+    atomic<bool> &success;
+};
+
+bool ColumnstoreStorage::DeleteFiles(const vector<string> &file_paths) {
+    TransactionGuard transaction_guard;
+    auto &context = *pgduckdb::DuckDBManager::GetConnectionUnsafe()->context;
+    auto &fs = FileSystem::GetFileSystem(context);
+    // Use DuckDB's task system for parallelization
+    TaskExecutor executor(context);
+    std::atomic<bool> success{true};
+
+    for (const auto &path : file_paths) {
+        auto task = make_uniq<FileDeleteTask>(executor, fs, path, success);
+        executor.ScheduleTask(std::move(task));
+    }
+    executor.WorkOnTasks();
+
+    return success;
+}
+
+bool ColumnstoreStorage::DeleteDirectory(const std::string &directory) {
+    TransactionGuard transaction_guard;
+    auto &context = *pgduckdb::DuckDBManager::GetConnectionUnsafe()->context;
+    auto &fs = FileSystem::GetFileSystem(context);
+
+    try {
+        pd_log(DEBUG1, "Deleting directory: %s", directory.c_str());
+        fs.RemoveDirectory(directory);
+        return true;
+    } catch (std::exception &e) {
+        pd_log(WARNING, "Failed to delete directory: %s", e.what());
+        return false;
+    }
+}
+
+void ColumnstoreStorageContextState::QueryEnd() {
+    pending_deletes.clear();
+}
+
+void ColumnstoreStorageContextState::RelationDropStorage(Oid relid) {
+    PendingRelDelete pending = {
+        .oid = relid, .nest_level = pgduckdb::pg::GetCurrentTransactionNestLevel(), .at_commit = true};
+
+    ColumnstoreMetadata metadata(NULL /*snapshot*/);
+    pending.table_path = metadata.GetTablePath(relid);
+    pending.file_names = metadata.DeadDataFilesSearch(relid);
+    pending_deletes.emplace_back(pending);
+}
+
+void ColumnstoreStorageContextState::DoPendingDeletes(bool isCommit) {
+    auto nest_level = pgduckdb::pg::GetCurrentTransactionNestLevel();
+
+    pending_deletes.remove_if([this, nest_level, isCommit](auto &pending) {
+        if (pending.nest_level < nest_level)
+            return false;
+
+        if (pending.at_commit == isCommit) {
+            pd_log(DEBUG1, "start deleting files of table: %d", pending.oid);
+            auto file_path = ColumnstoreTable::GetFilePaths(pending.table_path, pending.file_names, false);
+            if (!ColumnstoreStorage::DeleteFiles(file_path) ||
+                !ColumnstoreStorage::DeleteDirectory(pending.table_path)) {
+                return false;
+            }
+        }
+        return true;
+    });
+}
+
+void ColumnstoreStorageContextState::AtSubCommit() {
+    auto nest_level = pgduckdb::pg::GetCurrentTransactionNestLevel();
+    for (auto &pending : pending_deletes) {
+        if (pending.nest_level >= nest_level) {
+            pending.nest_level = nest_level - 1;
+        }
+    }
+}
+
+void ColumnstoreStorageContextState::AtSubAbort() {
+    DoPendingDeletes(false);
+}
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_storage.hpp
+++ b/src/columnstore/columnstore_storage.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "duckdb/common/list.hpp"
+#include "duckdb/main/client_context_state.hpp"
+#include "pgduckdb/pg/declarations.hpp"
+#include "pgduckdb/pgduckdb_duckdb.hpp"
+
+namespace duckdb {
+
+struct PendingRelDelete {
+public:
+    Oid oid;
+    int nest_level;
+    bool at_commit;
+    string table_path;
+    vector<string> file_names;
+};
+
+class ColumnstoreStorage {
+public:
+    static bool DeleteFiles(const vector<string> &file_paths);
+    static bool DeleteDirectory(const string &directory);
+};
+
+class ColumnstoreStorageContextState : public duckdb::ClientContextState {
+
+public:
+    static ColumnstoreStorageContextState &Get() {
+        auto &context = *pgduckdb::DuckDBManager::GetConnectionUnsafe()->context;
+        return Get(context);
+    }
+
+    static ColumnstoreStorageContextState &Get(duckdb::ClientContext &context) {
+        return *context.registered_state->GetOrCreate<ColumnstoreStorageContextState>("pgmooncake_storage");
+    }
+
+    void QueryEnd() override;
+
+    void RelationDropStorage(Oid relid);
+
+    void DoPendingDeletes(bool isCommit);
+
+    void AtSubCommit();
+
+    void AtSubAbort();
+private:
+    duckdb::list<PendingRelDelete> pending_deletes;
+};
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_table.cpp
+++ b/src/columnstore/columnstore_table.cpp
@@ -267,9 +267,9 @@ void ColumnstoreTable::Delete(ClientContext &context, unordered_set<row_t> &row_
     FinalizeInsert();
 }
 
-vector<string> ColumnstoreTable::GetFilePaths(const string &path, const vector<string> &file_names) {
+vector<string> ColumnstoreTable::GetFilePaths(const string &path, const vector<string> &file_names, bool allow_cache) {
     vector<string> file_paths;
-    if (mooncake_enable_local_cache && FileSystem::IsRemoteFile(path)) {
+    if (allow_cache && mooncake_enable_local_cache && FileSystem::IsRemoteFile(path)) {
         auto local_fs = FileSystem::CreateLocal();
         for (auto &file_name : file_names) {
             string cached_file_path = x_mooncake_local_cache + file_name;

--- a/src/columnstore/columnstore_table.hpp
+++ b/src/columnstore/columnstore_table.hpp
@@ -35,8 +35,9 @@ public:
     void Delete(ClientContext &context, unordered_set<row_t> &row_ids_set,
                 ColumnDataCollection *return_collection = nullptr);
 
+    static vector<string> GetFilePaths(const string &path, const vector<string> &file_names, bool allow_cache = true);
+
 private:
-    static vector<string> GetFilePaths(const string &path, const vector<string> &file_names);
 
     static idx_t Cardinality(const vector<string> &file_names);
 

--- a/src/columnstore/columnstore_xact.cpp
+++ b/src/columnstore/columnstore_xact.cpp
@@ -1,0 +1,34 @@
+#include "pgduckdb/pg/transactions.hpp"
+#include "pgduckdb/pgduckdb_duckdb.hpp"
+#include "pgduckdb/utility/cpp_wrapper.hpp"
+
+#include "columnstore/columnstore.hpp"
+#include "columnstore/columnstore_xact.hpp"
+#include "columnstore/columnstore_storage.hpp"
+
+namespace duckdb {
+
+void MooncakeXactCallback(XactEvent event) {
+    switch (event) {
+    case XACT_EVENT_COMMIT:
+        ColumnstoreStorageContextState::Get().DoPendingDeletes(true);
+        break;
+    default:
+        break;
+    }
+}
+
+void MooncakeSubXactCallback(SubXactEvent event) {
+    switch (event) {
+    case SUBXACT_EVENT_COMMIT_SUB:
+        ColumnstoreStorageContextState::Get().AtSubCommit();
+        break;
+    case SUBXACT_EVENT_ABORT_SUB:
+        ColumnstoreStorageContextState::Get().AtSubAbort();
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace duckdb

--- a/src/columnstore/columnstore_xact.hpp
+++ b/src/columnstore/columnstore_xact.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "pgduckdb/pg/transactions.hpp"
+
+namespace duckdb {
+
+void MooncakeXactCallback(XactEvent event);
+void MooncakeSubXactCallback(SubXactEvent event);
+
+} // namespace duckdb

--- a/src/pgduckdb/catalog/pgduckdb_transaction.cpp
+++ b/src/pgduckdb/catalog/pgduckdb_transaction.cpp
@@ -7,6 +7,7 @@
 
 #include "columnstore/columnstore_table.hpp"
 #include "columnstore_handler.hpp"
+#include "columnstore/columnstore_storage.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/catalog/catalog.hpp"
@@ -19,6 +20,8 @@ void
 ClosePostgresRelations(duckdb::ClientContext &context) {
 	auto context_state = context.registered_state->GetOrCreate<PostgresContextState>("pgduckdb");
 	context_state->QueryEnd();
+
+	duckdb::ColumnstoreStorageContextState::Get(context).QueryEnd();
 }
 
 PostgresTransaction::PostgresTransaction(duckdb::TransactionManager &_manager, duckdb::ClientContext &_context,

--- a/src/pgduckdb/logger.hpp
+++ b/src/pgduckdb/logger.hpp
@@ -46,7 +46,7 @@ namespace pgduckdb {
 		pd_prevent_errno_in_scope();                                                                                   \
 		static_assert(elevel >= DEBUG5 && elevel <= WARNING_CLIENT_ONLY, "Invalid error level");                       \
 		if (message_level_is_interesting(elevel)) {                                                                    \
-			std::lock_guard<std::mutex> lock(DuckdbProcessLock::GetLock());                                            \
+			std::lock_guard<std::mutex> lock(pgduckdb::DuckdbProcessLock::GetLock());                                  \
 			if (errstart(elevel, domain))                                                                              \
 				__VA_ARGS__, errfinish(__FILE__, __LINE__, __func__);                                                  \
 		}                                                                                                              \

--- a/src/pgduckdb/pg/transactions.cpp
+++ b/src/pgduckdb/pg/transactions.cpp
@@ -48,4 +48,9 @@ UnregisterSubXactCallback(SubXactCallback callback, void *arg) {
 	return PostgresFunctionGuard(::UnregisterSubXactCallback, callback, arg);
 }
 
+int
+GetCurrentTransactionNestLevel() {
+	return ::GetCurrentTransactionNestLevel();
+}
+
 } // namespace pgduckdb::pg

--- a/src/pgduckdb/pg/transactions.hpp
+++ b/src/pgduckdb/pg/transactions.hpp
@@ -41,4 +41,5 @@ void RegisterXactCallback(XactCallback callback, void *arg);
 void UnregisterXactCallback(XactCallback callback, void *arg);
 void RegisterSubXactCallback(SubXactCallback callback, void *arg);
 void UnregisterSubXactCallback(SubXactCallback callback, void *arg);
+int GetCurrentTransactionNestLevel();
 } // namespace pgduckdb::pg

--- a/src/pgduckdb/pgduckdb_ddl.cpp
+++ b/src/pgduckdb/pgduckdb_ddl.cpp
@@ -9,6 +9,7 @@ extern "C" {
 #include "postgres.h"
 #include "access/table.h"
 #include "access/tableam.h"
+#include "catalog/objectaccess.h"
 #include "catalog/pg_type.h"
 #include "commands/event_trigger.h"
 #include "fmgr.h"
@@ -37,6 +38,7 @@ extern "C" {
 #include "pgduckdb/pgduckdb_metadata_cache.hpp"
 #include "pgduckdb/utility/copy.hpp"
 #include "pgduckdb/vendor/pg_list.hpp"
+#include "columnstore/columnstore.hpp"
 #include <inttypes.h>
 
 /*
@@ -48,6 +50,7 @@ static bool ctas_skip_data = false;
 
 static bool top_level_ddl = true;
 static ProcessUtility_hook_type prev_process_utility_hook = NULL;
+static object_access_hook_type prev_object_access_hook = NULL;
 
 [[maybe_unused]] static void
 DuckdbHandleDDL(Node *parsetree) {
@@ -195,10 +198,27 @@ DuckdbUtilityHook(PlannedStmt *pstmt, const char *query_string, bool read_only_t
 	InvokeCPPFunc(DuckdbUtilityHook_Cpp, pstmt, query_string, read_only_tree, context, params, query_env, dest, qc);
 }
 
+static void
+MooncakeObjectAccessHook(ObjectAccessType access, Oid classId, Oid objectId, int subId, void *arg) {
+	if (prev_object_access_hook) {
+		prev_object_access_hook(access, classId, objectId, subId, arg);
+	}
+
+	ObjectAccessDrop *drop = (ObjectAccessDrop *)arg;
+	if (access == OAT_DROP && classId == RelationRelationId && !OidIsValid(subId)) {
+		if (IsColumnstoreTable(objectId)) {
+			duckdb::Columnstore::DropTable(objectId, drop->dropflags);
+		}
+	}
+}
+
 void
 DuckdbInitUtilityHook() {
 	prev_process_utility_hook = ProcessUtility_hook ? ProcessUtility_hook : standard_ProcessUtility;
 	ProcessUtility_hook = DuckdbUtilityHook;
+
+	prev_object_access_hook = object_access_hook;
+	object_access_hook = MooncakeObjectAccessHook;
 }
 
 /*

--- a/src/pgduckdb/pgduckdb_xact.cpp
+++ b/src/pgduckdb/pgduckdb_xact.cpp
@@ -1,4 +1,5 @@
 #include "columnstore/columnstore.hpp"
+#include "columnstore/columnstore_xact.hpp"
 #include "duckdb/common/exception.hpp"
 #include "pgduckdb/pgduckdb_duckdb.hpp"
 #include "pgduckdb/pgduckdb_utils.hpp"
@@ -141,6 +142,8 @@ DuckdbXactCallback_Cpp(XactEvent event) {
 		return;
 	}
 
+	duckdb::MooncakeXactCallback(event);
+
 	if (event == XACT_EVENT_ABORT || event == XACT_EVENT_PARALLEL_ABORT) {
 		duckdb::Columnstore::Abort();
 	} else if (event == XACT_EVENT_COMMIT || event == XACT_EVENT_PARALLEL_COMMIT) {
@@ -217,6 +220,9 @@ DuckdbSubXactCallback_Cpp(SubXactEvent event) {
 	if (!DuckDBManager::IsInitialized()) {
 		return;
 	}
+
+	duckdb::MooncakeSubXactCallback(event);
+
 	auto connection = DuckDBManager::GetConnectionUnsafe();
 	auto &context = *connection->context;
 	if (!context.transaction.HasActiveTransaction()) {

--- a/test/expected/gc_data_files.out
+++ b/test/expected/gc_data_files.out
@@ -1,0 +1,182 @@
+CREATE TABLE oid_tracker (oid oid, relname text);
+TRUNCATE TABLE mooncake.dead_data_files;
+-- case: temp table on commit drop
+BEGIN;
+CREATE TEMP TABLE t (a int) USING columnstore ON COMMIT DROP;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+INSERT INTO t SELECT * from generate_series(1, 1000);
+COMMIT;
+SELECT COUNT(*) FROM mooncake.dead_data_files;
+ count 
+-------
+     2
+(1 row)
+
+-- case: mark old data files for deletion
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+UPDATE t SET a = a + 1;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = 't'::regclass;
+ count 
+-------
+     1
+(1 row)
+
+DELETE FROM t WHERE a % 2 = 0;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = 't'::regclass;
+ count 
+-------
+     2
+(1 row)
+
+-- DROP should move all files to dead_data_files
+INSERT INTO oid_tracker (oid, relname) VALUES ('t'::regclass, 't');
+DROP TABLE t;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't');
+ count 
+-------
+     3
+(1 row)
+
+-- case: delete multiple tables
+CREATE TABLE t1 (a int) USING columnstore;
+CREATE TABLE t2 (a int) USING columnstore;
+CREATE TABLE t3 (a int) USING columnstore;
+INSERT INTO t1 SELECT * from generate_series(1, 1000);
+INSERT INTO t2 SELECT * from generate_series(1, 1000);
+INSERT INTO t3 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('t1'::regclass, 't1');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t2'::regclass, 't2');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t3'::regclass, 't3');
+DROP TABLE t1, t2, t3;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't1');
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't2');
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't3');
+ count 
+-------
+     1
+(1 row)
+
+-- case: truncate table
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+INSERT INTO t SELECT * from generate_series(1, 1000);
+TRUNCATE TABLE t;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = 't'::regclass;
+ count 
+-------
+     2
+(1 row)
+
+DROP TABLE t;
+-- case:  & drop materialized view
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+INSERT INTO t SELECT * from generate_series(1, 1000);
+CREATE MATERIALIZED VIEW mv USING columnstore AS SELECT * FROM t;
+INSERT INTO oid_tracker (oid, relname) VALUES ('mv'::regclass, 'mv');
+DROP MATERIALIZED VIEW mv;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 'mv');
+ count 
+-------
+     1
+(1 row)
+
+DROP TABLE t;
+-- TODO: add case for refresh mv. Currently, columnstore does not support refresh mv.
+-- case: drop schema cascade
+CREATE SCHEMA myschema;
+CREATE TABLE myschema.t1 (a int) USING columnstore;
+INSERT INTO myschema.t1 SELECT * from generate_series(1, 1000);
+CREATE TABLE myschema.t2 (a int) USING columnstore;
+INSERT INTO myschema.t2 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('myschema.t1'::regclass, 'myschema.t1');
+INSERT INTO oid_tracker (oid, relname) VALUES ('myschema.t2'::regclass, 'myschema.t2');
+DROP SCHEMA myschema CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to table myschema.t1
+drop cascades to table myschema.t2
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 'myschema.t1');
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 'myschema.t2');
+ count 
+-------
+     1
+(1 row)
+
+-- case: subtxn drop abort
+CREATE TABLE t11 (a int) USING columnstore;
+CREATE TABLE t12 (a int) USING columnstore;
+INSERT INTO t11 SELECT * from generate_series(1, 1000);
+INSERT INTO t12 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('t11'::regclass, 't11');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t12'::regclass, 't12');
+BEGIN;
+DROP TABLE t11;
+SAVEPOINT sp;
+DROP TABLE t12;
+ROLLBACK TO sp;
+COMMIT;
+-- t11 should be dropped while t12 should not be dropped
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't11');
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't12');
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE t12;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't12');
+ count 
+-------
+     1
+(1 row)
+
+-- case: subtxn drop commit
+CREATE TABLE t21 (a int) USING columnstore;
+CREATE TABLE t22 (a int) USING columnstore;
+INSERT INTO t21 SELECT * from generate_series(1, 1000);
+INSERT INTO t22 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('t21'::regclass, 't21');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t22'::regclass, 't22');
+BEGIN;
+DROP TABLE t21;
+SAVEPOINT sp;
+DROP TABLE t22;
+RELEASE SAVEPOINT sp;
+COMMIT;
+-- both t21 and t22 should be dropped
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't21');
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't22');
+ count 
+-------
+     1
+(1 row)
+
+-- cleanup
+TRUNCATE TABLE mooncake.dead_data_files;
+DROP TABLE oid_tracker;

--- a/test/sql/gc_data_files.sql
+++ b/test/sql/gc_data_files.sql
@@ -1,0 +1,108 @@
+CREATE TABLE oid_tracker (oid oid, relname text);
+TRUNCATE TABLE mooncake.dead_data_files;
+
+-- case: temp table on commit drop
+BEGIN;
+CREATE TEMP TABLE t (a int) USING columnstore ON COMMIT DROP;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+INSERT INTO t SELECT * from generate_series(1, 1000);
+COMMIT;
+SELECT COUNT(*) FROM mooncake.dead_data_files;
+
+-- case: mark old data files for deletion
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+UPDATE t SET a = a + 1;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = 't'::regclass;
+DELETE FROM t WHERE a % 2 = 0;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = 't'::regclass;
+-- DROP should move all files to dead_data_files
+INSERT INTO oid_tracker (oid, relname) VALUES ('t'::regclass, 't');
+DROP TABLE t;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't');
+
+-- case: delete multiple tables
+CREATE TABLE t1 (a int) USING columnstore;
+CREATE TABLE t2 (a int) USING columnstore;
+CREATE TABLE t3 (a int) USING columnstore;
+INSERT INTO t1 SELECT * from generate_series(1, 1000);
+INSERT INTO t2 SELECT * from generate_series(1, 1000);
+INSERT INTO t3 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('t1'::regclass, 't1');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t2'::regclass, 't2');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t3'::regclass, 't3');
+DROP TABLE t1, t2, t3;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't1');
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't2');
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't3');
+
+-- case: truncate table
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+INSERT INTO t SELECT * from generate_series(1, 1000);
+TRUNCATE TABLE t;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = 't'::regclass;
+DROP TABLE t;
+
+-- case:  & drop materialized view
+CREATE TABLE t (a int) USING columnstore;
+INSERT INTO t SELECT * from generate_series(1, 1000);
+INSERT INTO t SELECT * from generate_series(1, 1000);
+CREATE MATERIALIZED VIEW mv USING columnstore AS SELECT * FROM t;
+INSERT INTO oid_tracker (oid, relname) VALUES ('mv'::regclass, 'mv');
+DROP MATERIALIZED VIEW mv;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 'mv');
+DROP TABLE t;
+-- TODO: add case for refresh mv. Currently, columnstore does not support refresh mv.
+
+-- case: drop schema cascade
+CREATE SCHEMA myschema;
+CREATE TABLE myschema.t1 (a int) USING columnstore;
+INSERT INTO myschema.t1 SELECT * from generate_series(1, 1000);
+CREATE TABLE myschema.t2 (a int) USING columnstore;
+INSERT INTO myschema.t2 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('myschema.t1'::regclass, 'myschema.t1');
+INSERT INTO oid_tracker (oid, relname) VALUES ('myschema.t2'::regclass, 'myschema.t2');
+DROP SCHEMA myschema CASCADE;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 'myschema.t1');
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 'myschema.t2');
+
+-- case: subtxn drop abort
+CREATE TABLE t11 (a int) USING columnstore;
+CREATE TABLE t12 (a int) USING columnstore;
+INSERT INTO t11 SELECT * from generate_series(1, 1000);
+INSERT INTO t12 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('t11'::regclass, 't11');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t12'::regclass, 't12');
+BEGIN;
+DROP TABLE t11;
+SAVEPOINT sp;
+DROP TABLE t12;
+ROLLBACK TO sp;
+COMMIT;
+-- t11 should be dropped while t12 should not be dropped
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't11');
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't12');
+DROP TABLE t12;
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't12');
+
+-- case: subtxn drop commit
+CREATE TABLE t21 (a int) USING columnstore;
+CREATE TABLE t22 (a int) USING columnstore;
+INSERT INTO t21 SELECT * from generate_series(1, 1000);
+INSERT INTO t22 SELECT * from generate_series(1, 1000);
+INSERT INTO oid_tracker (oid, relname) VALUES ('t21'::regclass, 't21');
+INSERT INTO oid_tracker (oid, relname) VALUES ('t22'::regclass, 't22');
+BEGIN;
+DROP TABLE t21;
+SAVEPOINT sp;
+DROP TABLE t22;
+RELEASE SAVEPOINT sp;
+COMMIT;
+-- both t21 and t22 should be dropped
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't21');
+SELECT COUNT(*) FROM mooncake.dead_data_files WHERE oid = (select oid from oid_tracker where relname = 't22');
+
+-- cleanup
+TRUNCATE TABLE mooncake.dead_data_files;
+DROP TABLE oid_tracker;


### PR DESCRIPTION
- Introduce a metadata table `dead_data_files` to store files marked for deletion.
- Data files of DROPPED TABLES are tracked in memory and deleted with best effort after commit.

**Issue left**: Currently, file deletion relies on duckdb's filesystem abstraction. However, the s3 filesystem shipped by duckdb`httpfs` does not implement the `RemoveFiles` interface. So this PR only handles the deletion of local data files.

**Optional solutions**: Move the `httpfs` extension out of duckdb and maintain it in `pg_mooncake`, similar to how `pg_duckdb` manages `cached_httpfs`. Or reuse `cached_httpfs` after merging the latest release of `pg_duckdb`.

to #22 