### PR TITLE
Set search_path for create_secret and drop_secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.3 (2025-12-01)
+### Added
+- Retrieve correct cardinality for columnstore scan (#125)
+### Fixed
+- Disable local filesystem when allow_local_tables is off
+- Set search_path for create_secret and drop_secret (#180)
+
 ## 0.1.2 (2025-02-11)
 ### Added
 - Support NOT NULL constraint (#116)

--- a/Makefile.build
+++ b/Makefile.build
@@ -50,7 +50,8 @@ MODULES := libduckdb
 MODULE_big := $(EXTENSION_NAME)
 DATA := $(SQL_DIR)/pg_mooncake--0.1.0.sql \
         $(SQL_DIR)/pg_mooncake--0.1.0--0.1.1.sql \
-        $(SQL_DIR)/pg_mooncake--0.1.1--0.1.2.sql
+        $(SQL_DIR)/pg_mooncake--0.1.1--0.1.2.sql \
+        $(SQL_DIR)/pg_mooncake--0.1.2--0.1.3.sql
 EXTENSION := ../../$(EXTENSION_NAME)
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 override with_llvm := no

--- a/pg_mooncake.control
+++ b/pg_mooncake.control
@@ -1,4 +1,4 @@
 comment = 'Columnstore Table in Postgres'
-default_version = '0.1.2'
+default_version = '0.1.3'
 module_pathname = '$libdir/pg_mooncake'
 relocatable = true

--- a/sql/pg_mooncake--0.1.0.sql
+++ b/sql/pg_mooncake--0.1.0.sql
@@ -273,6 +273,7 @@ CREATE OR REPLACE FUNCTION mooncake.create_secret(
 )
 RETURNS VOID
 LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
 AS $create_secret$
 DECLARE
     allowed_keys TEXT[] := ARRAY['ENDPOINT', 'REGION', 'SCOPE', 'USE_SSL'];
@@ -329,6 +330,7 @@ $create_secret$ SECURITY DEFINER;
 CREATE OR REPLACE FUNCTION mooncake.drop_secret(secret_name TEXT)
 RETURNS VOID
 LANGUAGE plpgsql
+SET search_path = pg_catalog, pg_temp
 AS $drop_secret$
 BEGIN
     DELETE FROM mooncake.secrets WHERE name = secret_name;

--- a/sql/pg_mooncake--0.1.2--0.1.3.sql
+++ b/sql/pg_mooncake--0.1.2--0.1.3.sql
@@ -1,0 +1,2 @@
+ALTER FUNCTION mooncake.create_secret SET search_path = pg_catalog, pg_temp;
+ALTER FUNCTION mooncake.drop_secret SET search_path = pg_catalog, pg_temp;


### PR DESCRIPTION
Set search_path for create_secret and drop_secret to prevent malicious users from creating shadow functions and hijacking the control flow

Also bump pg_mooncake to v0.1.3